### PR TITLE
VM disk-ops benchmark support

### DIFF
--- a/dashboard/generate_dashboard.py
+++ b/dashboard/generate_dashboard.py
@@ -1297,6 +1297,337 @@ def build_elbencho_content(folder: Path, uid: str) -> str:
     """
 
 
+# ---------------- Disk Ops Benchmark Builder ----------------
+def build_disk_ops_content(folder: Path, uid: str) -> str:
+    """Disk Operations Benchmark section - hotplug, coldplug, and unplug timing metrics."""
+    import json as _json
+
+    data = load_json(folder / "disk_ops_results.json")
+
+    if not data:
+        return "<p>No disk operations benchmark data found.</p>"
+
+    config = data.get("config", {})
+    summary = data.get("summary", {})
+    hotplug = data.get("hotplug") or {}
+    coldplug = data.get("coldplug") or {}
+    unplug = data.get("unplug") or {}
+    per_vm = data.get("per_vm_results", []) or []
+
+    timestamp = data.get("timestamp", "N/A")
+    total_vms = summary.get("total_vms", 0)
+    total_ops = summary.get("total_operations", 0)
+
+    # Header
+    header_html = f"""
+    <h6><strong>Timestamp:</strong> {timestamp}</h6>
+    <h6><strong>Total VMs:</strong> {total_vms} &nbsp;|&nbsp; <strong>Total Operations:</strong> {total_ops}</h6>
+    """
+
+    # Config table
+    op_label = config.get("operation", "N/A").upper()
+    config_rows = "".join([
+        f"<tr><th>Operation</th><td>{op_label}</td></tr>",
+        f"<tr><th>Disks per VM</th><td>{config.get('disks_per_vm', 'N/A')}</td></tr>",
+        f"<tr><th>Disk Size</th><td>{config.get('disk_size', 'N/A')}</td></tr>",
+        f"<tr><th>Storage Class</th><td>{config.get('storage_class', 'N/A')}</td></tr>",
+        f"<tr><th>Test Unplug</th><td>{'Yes' if config.get('test_unplug') else 'No'}</td></tr>",
+        f"<tr><th>Skip Validation</th><td>{'Yes' if config.get('skip_validation') else 'No'}</td></tr>",
+    ])
+    config_table = f'<table class="table table-bordered w-auto"><tbody>{config_rows}</tbody></table>'
+
+    # KPI cards — success rates for all three operations
+    def success_pct(d):
+        c = d.get("count", 0)
+        s = d.get("success_count", 0)
+        return f"{s}/{c} ({100*s/c:.0f}%)" if c else "N/A"
+
+    hp_rate = success_pct(hotplug) if hotplug else "N/A"
+    cp_rate = success_pct(coldplug) if coldplug else "N/A"
+    up_rate = success_pct(unplug) if unplug else "N/A"
+
+    kpi_html = f"""
+    <div class="row mb-4">
+      <div class="col-md-3">
+        <div class="card text-center border-0 shadow-sm" style="background: #1e3a5f;">
+          <div class="card-body py-3">
+            <div style="color:rgba(255,255,255,0.7);font-size:0.8rem;">Total VMs</div>
+            <div class="text-white fw-bold fs-4">{total_vms}</div>
+          </div>
+        </div>
+      </div>
+      <div class="col-md-3">
+        <div class="card text-center border-0 shadow-sm" style="background: #1e3a5f;">
+          <div class="card-body py-3">
+            <div style="color:rgba(255,255,255,0.7);font-size:0.8rem;">Hotplug Success</div>
+            <div class="text-white fw-bold fs-4">{hp_rate}</div>
+          </div>
+        </div>
+      </div>
+      <div class="col-md-3">
+        <div class="card text-center border-0 shadow-sm" style="background: #1e3a5f;">
+          <div class="card-body py-3">
+            <div style="color:rgba(255,255,255,0.7);font-size:0.8rem;">Coldplug Success</div>
+            <div class="text-white fw-bold fs-4">{cp_rate}</div>
+          </div>
+        </div>
+      </div>
+      <div class="col-md-3">
+        <div class="card text-center border-0 shadow-sm" style="background: #1e3a5f;">
+          <div class="card-body py-3">
+            <div style="color:rgba(255,255,255,0.7);font-size:0.8rem;">Unplug Success</div>
+            <div class="text-white fw-bold fs-4">{up_rate}</div>
+          </div>
+        </div>
+      </div>
+    </div>
+    """
+
+    # Operation summary tables
+    def op_table(title, d, extra_rows=""):
+        if not d:
+            return ""
+        count = d.get("count", 0)
+        success = d.get("success_count", 0)
+        badge = "bg-success" if success == count else ("bg-warning text-dark" if success > 0 else "bg-danger")
+        rows = f"""
+        <tr><th>VMs</th><td>{count}</td></tr>
+        <tr><th>Successful</th><td><span class="badge {badge}">{success}/{count}</span></td></tr>
+        {extra_rows}
+        <tr><th>Avg Total Time</th><td>{d.get('avg_total_time', 0):.3f} s</td></tr>
+        """
+        return f"""
+        <div class="col-md-4">
+          <div class="card shadow-sm h-100">
+            <div class="card-header bg-dark text-white"><strong>{title}</strong></div>
+            <div class="card-body p-2">
+              <table class="table table-sm table-bordered mb-0"><tbody>{rows}</tbody></table>
+            </div>
+          </div>
+        </div>
+        """
+
+    hp_extra = f"""
+    <tr><th>Disks Attached</th><td>{hotplug.get('total_disks_attached', 0)}</td></tr>
+    <tr><th>Disks Validated</th><td>{hotplug.get('total_disks_validated', 0)}</td></tr>
+    <tr><th>Avg API Attach</th><td>{hotplug.get('avg_api_attach_time', 0):.3f} s</td></tr>
+    <tr><th>Avg Volume Ready</th><td>{hotplug.get('avg_volume_ready_time', 0):.3f} s</td></tr>
+    <tr><th>Avg Validation</th><td>{hotplug.get('avg_validation_time', 0):.3f} s</td></tr>
+    """ if hotplug else ""
+
+    cp_extra = f"""
+    <tr><th>Disks Attached</th><td>{coldplug.get('total_disks_attached', 0)}</td></tr>
+    <tr><th>Disks Validated</th><td>{coldplug.get('total_disks_validated', 0)}</td></tr>
+    <tr><th>Avg API Attach</th><td>{coldplug.get('avg_api_attach_time', 0):.3f} s</td></tr>
+    <tr><th>Avg VM Boot</th><td>{coldplug.get('avg_vm_boot_time', 0):.3f} s</td></tr>
+    <tr><th>Avg Validation</th><td>{coldplug.get('avg_validation_time', 0):.3f} s</td></tr>
+    """ if coldplug else ""
+
+    up_extra = f"""
+    <tr><th>Disks Removed</th><td>{unplug.get('total_disks_removed', 0)}</td></tr>
+    """ if unplug else ""
+
+    ops_html = f"""
+    <div class="row mb-4">
+      {op_table("Hotplug", hotplug, hp_extra)}
+      {op_table("Coldplug", coldplug, cp_extra)}
+      {op_table("Unplug", unplug, up_extra)}
+    </div>
+    """
+
+    # Chart — only total time per operation (no validation/phase breakdown)
+    chart_labels, chart_data, chart_colors = [], [], []
+    if hotplug:
+        chart_labels.append("Hotplug Total")
+        chart_data.append(hotplug.get("avg_total_time", 0))
+        chart_colors.append("rgba(52,152,219,0.85)")
+    if coldplug:
+        chart_labels.append("Coldplug Total")
+        chart_data.append(coldplug.get("avg_total_time", 0))
+        chart_colors.append("rgba(46,204,113,0.85)")
+    if unplug:
+        chart_labels.append("Unplug Total")
+        chart_data.append(unplug.get("avg_total_time", 0))
+        chart_colors.append("rgba(231,76,60,0.85)")
+
+    chart_html = ""
+    if chart_data:
+        chart_html = f"""
+        <div class="card shadow-sm mb-4">
+          <div class="card-header bg-dark text-white">
+            <strong>Average Total Time per Operation (seconds)</strong>
+          </div>
+          <div class="card-body">
+            <canvas id="diskOpsTimingChart_{uid}" height="80"></canvas>
+          </div>
+        </div>
+        <script>
+          new Chart(document.getElementById('diskOpsTimingChart_{uid}'), {{
+            type: 'bar',
+            data: {{
+              labels: {_json.dumps(chart_labels)},
+              datasets: [{{
+                data: {_json.dumps(chart_data)},
+                backgroundColor: {_json.dumps(chart_colors)},
+                borderRadius: 6,
+                borderSkipped: false
+              }}]
+            }},
+            options: {{
+              responsive: true,
+              plugins: {{
+                legend: {{ display: false }},
+                tooltip: {{ callbacks: {{ label: function(ctx) {{ return ctx.parsed.y.toFixed(3) + ' s'; }} }} }}
+              }},
+              scales: {{
+                y: {{ beginAtZero: true, title: {{ display: true, text: 'Seconds' }} }}
+              }}
+            }}
+          }});
+        </script>
+        """
+
+    # Per-VM table with click-to-chart popup
+    per_vm_js = []
+    per_vm_rows = ""
+    for idx, r in enumerate(per_vm):
+        ns = r.get("namespace", "N/A")
+        op = r.get("operation", "N/A")
+        d_req = r.get("disks_requested", r.get("disks_removed", 0))
+        d_att = r.get("disks_attached", r.get("disks_removed", "-"))
+        d_val = r.get("disks_validated", "-")
+        t_sec = r.get("total_time", 0)
+        ok = r.get("success", False)
+        errors = "; ".join(r.get("errors", [])) if r.get("errors") else ""
+        badge = '<span class="badge bg-success">✓</span>' if ok else f'<span class="badge bg-danger" title="{errors}">✗</span>'
+
+        # Build per-operation chart data depending on type
+        if op == "hotplug":
+            chart_labels_vm = ["API Attach", "Vol Ready", "Total"]
+            chart_vals_vm   = [r.get("api_attach_time", 0), r.get("volume_ready_time", 0), r.get("total_time", 0)]
+            bar_colors_vm   = ["#3498db", "#9b59b6", "#2980b9"]
+        elif op == "coldplug":
+            chart_labels_vm = ["API Attach", "VM Boot", "Total"]
+            chart_vals_vm   = [r.get("api_attach_time", 0), r.get("vm_boot_time", 0), r.get("total_time", 0)]
+            bar_colors_vm   = ["#2ecc71", "#f39c12", "#27ae60"]
+        else:  # unplug
+            chart_labels_vm = ["Total"]
+            chart_vals_vm   = [r.get("total_time", 0)]
+            bar_colors_vm   = ["#e74c3c"]
+
+        per_vm_js.append({
+            "ns": ns, "op": op,
+            "labels": chart_labels_vm,
+            "vals": chart_vals_vm,
+            "colors": bar_colors_vm
+        })
+
+        per_vm_rows += f"""
+        <tr style="cursor:pointer;" onclick="showDiskOpsVmChart_{uid}({idx})">
+          <td>{badge} <a href="#" onclick="event.preventDefault();showDiskOpsVmChart_{uid}({idx});">{ns}</a></td>
+          <td>{op}</td>
+          <td>{d_req}</td>
+          <td>{d_att}</td>
+          <td>{d_val}</td>
+          <td>{t_sec:.3f}</td>
+        </tr>
+        """
+
+    per_vm_js_json = _json.dumps(per_vm_js)
+    no_data_row = "<tr><td colspan='6' class='text-center text-muted'>No per-VM results recorded.</td></tr>"
+
+    per_vm_table = f"""
+    <table class="table table-sm table-hover table-striped">
+      <thead class="table-light">
+        <tr>
+          <th>Namespace</th><th>Operation</th><th>Disks Requested</th>
+          <th>Disks Attached</th><th>Disks Validated</th><th>Total Time (s)</th>
+        </tr>
+      </thead>
+      <tbody>{per_vm_rows if per_vm_rows else no_data_row}</tbody>
+    </table>
+
+    <!-- Per-VM chart modal -->
+    <div id="diskOpsVmModal_{uid}" class="modal fade" tabindex="-1">
+      <div class="modal-dialog modal-lg">
+        <div class="modal-content">
+          <div class="modal-header">
+            <h5 class="modal-title" id="diskOpsVmModalTitle_{uid}">Operation Timing</h5>
+            <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+          </div>
+          <div class="modal-body">
+            <canvas id="diskOpsVmChart_{uid}" height="180"></canvas>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <script>
+      var diskOpsVmData_{uid} = {per_vm_js_json};
+      var diskOpsVmChartInst_{uid} = null;
+      var diskOpsModalInst_{uid} = null;
+
+      (function() {{
+        var modalEl = document.getElementById('diskOpsVmModal_{uid}');
+        diskOpsModalInst_{uid} = new bootstrap.Modal(modalEl, {{ backdrop: true }});
+        modalEl.addEventListener('hidden.bs.modal', function() {{
+          document.body.classList.remove('modal-open');
+          document.body.style.removeProperty('overflow');
+          document.body.style.removeProperty('padding-right');
+          document.querySelectorAll('.modal-backdrop').forEach(function(el) {{ el.remove(); }});
+        }});
+      }})();
+
+      function showDiskOpsVmChart_{uid}(idx) {{
+        var d = diskOpsVmData_{uid}[idx];
+        document.getElementById('diskOpsVmModalTitle_{uid}').innerText =
+          d.ns + ' — ' + d.op.charAt(0).toUpperCase() + d.op.slice(1) + ' Timing';
+
+        if (diskOpsVmChartInst_{uid}) {{ diskOpsVmChartInst_{uid}.destroy(); diskOpsVmChartInst_{uid} = null; }}
+
+        diskOpsVmChartInst_{uid} = new Chart(document.getElementById('diskOpsVmChart_{uid}'), {{
+          type: 'bar',
+          data: {{
+            labels: d.labels,
+            datasets: [{{
+              data: d.vals,
+              backgroundColor: d.colors,
+              borderRadius: 6,
+              borderSkipped: false
+            }}]
+          }},
+          options: {{
+            responsive: true,
+            plugins: {{
+              legend: {{ display: false }},
+              tooltip: {{ callbacks: {{ label: function(ctx) {{ return ctx.parsed.y.toFixed(3) + ' s'; }} }} }}
+            }},
+            scales: {{
+              y: {{ beginAtZero: true, title: {{ display: true, text: 'Seconds' }} }}
+            }}
+          }}
+        }});
+
+        diskOpsModalInst_{uid}.show();
+      }}
+    </script>
+    """
+
+    return f"""
+    <div class="mb-4">
+      {header_html}
+      {kpi_html}
+      <h4 class="mt-4">Test Configuration</h4>
+      {config_table}
+      <h4 class="mt-4">Operation Results</h4>
+      {ops_html}
+      {chart_html}
+      <h4 class="mt-4">Per-VM Details <small class="text-muted fs-6">(click a row to view timing chart)</small></h4>
+      {per_vm_table}
+    </div>
+    """
+
+
 # ---------------- Disk and PX Builders ----------------
 def build_disk_tab(px_version: str, disk_name: str, folders: list) -> str:
     """Disk-level tab with charts and nested VM-size tabs."""
@@ -1378,10 +1709,36 @@ def build_disk_tab(px_version: str, disk_name: str, folders: list) -> str:
             for f in by_vms[vm_count] if (f / "aggregated_results.json").exists()
         ) or "<p>No Elbencho Benchmark data for this VM size.</p>"
 
+        disk_ops_folders = [f for f in by_vms[vm_count] if (f / "disk_ops_results.json").exists()]
+        if disk_ops_folders:
+            accordion_items = []
+            for aidx, f in enumerate(disk_ops_folders):
+                fold_uid = f"{px_version}_{disk_name}_{vm_count}_{f.name}".replace(".", "_").replace("-", "_")
+                content = build_disk_ops_content(f, uid=fold_uid)
+                expanded = "show" if aidx == 0 else ""
+                collapsed = "" if aidx == 0 else "collapsed"
+                accordion_items.append(f"""
+                <div class="accordion-item">
+                  <h2 class="accordion-header">
+                    <button class="accordion-button {collapsed}" type="button"
+                            data-bs-toggle="collapse" data-bs-target="#diskops_acc_{fold_uid}">
+                      {f.name}
+                    </button>
+                  </h2>
+                  <div id="diskops_acc_{fold_uid}" class="accordion-collapse collapse {expanded}">
+                    <div class="accordion-body">{content}</div>
+                  </div>
+                </div>
+                """)
+            disk_ops_sections = f'<div class="accordion" id="diskOpsAccordion_{vm_id}">{"".join(accordion_items)}</div>'
+        else:
+            disk_ops_sections = "<p>No Disk Operations benchmark data for this VM size.</p>"
+
         # Check if we have capacity/fio/elbencho data to show the tabs
         has_capacity_data = any((f / "summary_capacity_benchmark.json").exists() for f in by_vms[vm_count])
         has_fio_data = any((f / "summary_fio_benchmark.json").exists() or (f / "fio_benchmark_results.json").exists() for f in by_vms[vm_count])
         has_elbencho_data = any((f / "aggregated_results.json").exists() for f in by_vms[vm_count])
+        has_disk_ops_data = any((f / "disk_ops_results.json").exists() for f in by_vms[vm_count])
         # Check if we have chaos data to show the tab
         has_capacity_data = any((f / "summary_chaos_benchmark.json").exists() for f in by_vms[vm_count])
 
@@ -1417,6 +1774,14 @@ def build_disk_tab(px_version: str, disk_name: str, folders: list) -> str:
             )
             tab_content_items.append(
                 f'<div class="tab-pane fade" id="tab_{vm_id}_elbencho" role="tabpanel">{elbencho_sections}</div>'
+            )
+
+        if has_disk_ops_data:
+            tab_nav_items.append(
+                f'<li class="nav-item"><button class="nav-link" id="tab-{vm_id}_diskops-tab" data-bs-toggle="tab" data-bs-target="#tab_{vm_id}_diskops" type="button" role="tab">Disk Ops</button></li>'
+            )
+            tab_content_items.append(
+                f'<div class="tab-pane fade" id="tab_{vm_id}_diskops" role="tabpanel">{disk_ops_sections}</div>'
             )
 
         vm_tabs_body.append(

--- a/disk-ops-benchmark/measure-disk-ops.py
+++ b/disk-ops-benchmark/measure-disk-ops.py
@@ -1,0 +1,1178 @@
+#!/usr/bin/env python3
+"""
+Disk Operations Benchmark - Hotplug/Coldplug disk performance testing for KubeVirt VMs.
+
+Measures:
+- Hotplug: Attach disk to running VM
+- Coldplug: Attach disk to stopped VM, then start
+- Validation: Verify disk appears inside VM via SSH
+"""
+
+import argparse
+import json
+import logging
+import os
+import re
+import subprocess
+import sys
+import time
+import uuid
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from datetime import datetime
+from typing import Dict, List, Optional, Tuple
+
+# Reuse the shared SSH helper that runs `kubectl exec` into a persistent
+# sshpass-equipped pod (same approach as the FIO benchmark).
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from utils.common import ssh_exec_command
+
+# Constants
+DEFAULT_NAMESPACE_PREFIX = 'disk-ops'
+DEFAULT_VM_NAME = 'disk-ops-vm'
+DEFAULT_VM_TEMPLATE = 'vm-template.yaml'
+DEFAULT_DISK_SIZE = '10Gi'
+DEFAULT_CONCURRENCY = 10
+DEFAULT_SSH_TIMEOUT = 120
+DEFAULT_ATTACH_TIMEOUT = 300
+DEFAULT_VM_TIMEOUT = 600
+DEFAULT_VM_USER = 'cloud-user'
+DEFAULT_VM_PASSWORD = 'changeme'
+DEFAULT_SSH_POD = 'ssh-test-pod'
+DEFAULT_SSH_POD_NS = 'default'
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description='Disk Operations Benchmark - Test hotplug/coldplug performance',
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  # Hotplug 3 disks to 10 VMs
+  python3 measure-disk-ops.py --start 1 --end 10 --operation hotplug --disks 3
+
+  # Coldplug 1 disk to 5 VMs
+  python3 measure-disk-ops.py --start 1 --end 5 --operation coldplug --disks 1
+
+  # Both operations with unplug test
+  python3 measure-disk-ops.py --start 1 --end 10 --operation all --disks 2 --test-unplug
+        """
+    )
+
+    # Required arguments
+    parser.add_argument('--start', '-s', type=int, required=True, help='Start namespace index')
+    parser.add_argument('--end', '-e', type=int, required=True, help='End namespace index')
+    parser.add_argument('--storage-class', type=str, required=True, help='Storage class for PVCs')
+
+    # Operation settings
+    parser.add_argument('--operation', type=str, default='all',
+                        choices=['hotplug', 'coldplug', 'all'],
+                        help='Operation type (default: all)')
+    parser.add_argument('--disks', type=int, default=1, help='Number of disks per VM (default: 1)')
+    parser.add_argument('--disk-size', type=str, default=DEFAULT_DISK_SIZE, help='Disk size (default: 10Gi)')
+    parser.add_argument('--parallel-attach', action='store_true',
+                        help='Attach all disks in parallel (default: sequential)')
+    parser.add_argument('--test-unplug', action='store_true', help='Also test disk removal')
+
+    # VM settings
+    parser.add_argument('--namespace-prefix', type=str, default=DEFAULT_NAMESPACE_PREFIX)
+    parser.add_argument('--vm-name', type=str, default=DEFAULT_VM_NAME)
+    parser.add_argument('--vm-template', type=str, default=DEFAULT_VM_TEMPLATE, help='VM template YAML')
+    parser.add_argument('--vm-user', type=str, default=DEFAULT_VM_USER, help='VM SSH user (default: cloud-user)')
+    parser.add_argument('--vm-password', type=str, default=DEFAULT_VM_PASSWORD,
+                        help='VM SSH password for in-VM validation (default: changeme)')
+    parser.add_argument('--ssh-pod', type=str, default=DEFAULT_SSH_POD,
+                        help='Persistent SSH helper pod with sshpass (auto-created if missing)')
+    parser.add_argument('--ssh-pod-ns', type=str, default=DEFAULT_SSH_POD_NS, help='SSH helper pod namespace')
+    parser.add_argument('--create-vms', action='store_true', help='Create VMs before testing')
+
+    # Execution settings
+    parser.add_argument('--concurrency', '-c', type=int, default=DEFAULT_CONCURRENCY)
+    parser.add_argument('--attach-timeout', type=int, default=DEFAULT_ATTACH_TIMEOUT,
+                        help='Timeout for disk attach (default: 300s)')
+    parser.add_argument('--vm-timeout', type=int, default=DEFAULT_VM_TIMEOUT,
+                        help='Timeout for created VMs to reach Running, incl. image import (default: 600s)')
+    parser.add_argument('--skip-validation', action='store_true', help='Skip in-VM validation')
+
+    # Output settings
+    parser.add_argument('--results-dir', type=str, default='results')
+    parser.add_argument('--save-results', action='store_true')
+    parser.add_argument('--px-version', type=str, default='px-unknown', help='Portworx version for results grouping')
+    parser.add_argument('--disk-type', type=str, default=None,
+                        help='Disk type label for results grouping (default: <disks>-disk)')
+    parser.add_argument('--cleanup', action='store_true', help='Remove hotplugged disks after test')
+
+    # Logging
+    parser.add_argument('--log-level', type=str, default='INFO',
+                        choices=['DEBUG', 'INFO', 'WARNING', 'ERROR'])
+    parser.add_argument('--log-file', type=str, default=None,
+                        help='Log file path (logs also go to the console)')
+
+    return parser.parse_args()
+
+
+def setup_logging(level: str, log_file: Optional[str] = None) -> logging.Logger:
+    handlers = [logging.StreamHandler()]
+    if log_file:
+        handlers.append(logging.FileHandler(log_file))
+    logging.basicConfig(
+        level=getattr(logging, level),
+        format='%(asctime)s - %(levelname)s - %(message)s',
+        datefmt='%Y-%m-%d %H:%M:%S',
+        handlers=handlers
+    )
+    return logging.getLogger(__name__)
+
+
+
+
+
+def ensure_ssh_pod(ssh_pod: str, ssh_pod_ns: str, logger, timeout: int = 180) -> Tuple[bool, bool]:
+    """
+    Ensure a persistent SSH helper pod (with sshpass) is running and usable.
+
+    Reuses the pod if it already exists; otherwise creates it and waits until
+    sshpass is installed. Returns (ready, created_by_us).
+    """
+    def sshpass_ready() -> bool:
+        rc, _, _ = run_cmd(f"kubectl exec -n {ssh_pod_ns} {ssh_pod} -- which sshpass", timeout=15)
+        return rc == 0
+
+    if sshpass_ready():
+        logger.info(f"Using existing SSH helper pod {ssh_pod_ns}/{ssh_pod}")
+        return True, False
+
+    created = False
+    rc, _, _ = run_cmd(f"kubectl get pod {ssh_pod} -n {ssh_pod_ns}", timeout=15)
+    if rc != 0:
+        logger.info(f"Creating SSH helper pod {ssh_pod_ns}/{ssh_pod}...")
+        run_cmd(f"kubectl create namespace {ssh_pod_ns} --dry-run=client -o yaml | kubectl apply -f -", timeout=20)
+        manifest = f"""apiVersion: v1
+kind: Pod
+metadata:
+  name: {ssh_pod}
+  namespace: {ssh_pod_ns}
+  labels:
+    app: kubevirt-perf-test
+spec:
+  containers:
+  - name: ssh-client
+    image: alpine:latest
+    command: ["/bin/sh", "-c", "apk add --no-cache bash openssh-client sshpass iputils && tail -f /dev/null"]
+    resources:
+      requests:
+        memory: "128Mi"
+        cpu: "100m"
+      limits:
+        memory: "256Mi"
+        cpu: "200m"
+  restartPolicy: Always
+"""
+        result = subprocess.run(['kubectl', 'apply', '-f', '-'], input=manifest.encode(), capture_output=True)
+        if result.returncode != 0:
+            logger.error(f"Failed to create SSH helper pod: {result.stderr.decode().strip()}")
+            return False, False
+        created = True
+
+    # Pod runs `apk add` on startup; wait until sshpass is actually available.
+    start = time.time()
+    while time.time() - start < timeout:
+        if sshpass_ready():
+            logger.info(f"SSH helper pod {ssh_pod_ns}/{ssh_pod} is ready")
+            return True, created
+        time.sleep(5)
+
+    logger.error(f"SSH helper pod {ssh_pod_ns}/{ssh_pod} not ready after {timeout}s")
+    return False, created
+
+
+def prepare_vm_yaml(template_path: str, vm_name: str, storage_class: str, vm_password: str) -> str:
+    """Prepare VM YAML with substituted values."""
+    with open(template_path) as f:
+        content = f.read()
+
+    replacements = {
+        '{{VM_NAME}}': vm_name,
+        '{{STORAGE_CLASS}}': storage_class,
+        '{{STORAGE_CLASS_NAME}}': storage_class,  # alias used by other repo templates
+        '{{VM_PASSWORD}}': vm_password,
+    }
+
+    for placeholder, value in replacements.items():
+        content = content.replace(placeholder, value)
+
+    return content
+
+
+def create_namespace(namespace: str) -> bool:
+    """Create a namespace if it doesn't exist."""
+    cmd = f"kubectl create namespace {namespace} --dry-run=client -o yaml | kubectl apply -f -"
+    rc, _, _ = run_cmd(cmd)
+    return rc == 0
+
+
+def deploy_vm(namespace: str, vm_yaml: str, logger) -> bool:
+    """Deploy a VM to a namespace."""
+    result = subprocess.run(
+        f"kubectl apply -n {namespace} -f -",
+        shell=True, input=vm_yaml.encode(), capture_output=True
+    )
+    if result.returncode == 0:
+        logger.info(f"[{namespace}] VM deployed")
+        return True
+    else:
+        logger.error(f"[{namespace}] VM deploy failed: {result.stderr.decode()}")
+        return False
+
+
+# VM states that indicate a stuck/failed VM unlikely to recover on its own.
+_VM_PROBLEM_HINTS = ('err', 'fail', 'crashloop', 'unschedulable', 'backoff', 'pull')
+
+
+def wait_for_vms_running(namespaces: List[str], vm_name: str, timeout: int, logger,
+                         poll_interval: int = 10) -> List[str]:
+    """
+    Wait for VMs to reach Running state, reporting live progress.
+
+    Emits a per-cycle breakdown of what the not-yet-running VMs are doing (e.g.
+    Provisioning while the disk image imports) so the wait never looks hung, and
+    flags VMs stuck in error states. Returns the list of running namespaces.
+    """
+    running = set()
+    warned = set()
+    start = time.time()
+
+    logger.info(f"Waiting for {len(namespaces)} VMs to be Running (timeout: {timeout}s)...")
+
+    while time.time() - start < timeout and len(running) < len(namespaces):
+        state_counts = {}
+        for ns in namespaces:
+            if ns in running:
+                continue
+            vm_status, vmi_phase = get_vm_status(ns, vm_name)
+            if vmi_phase == "Running":
+                running.add(ns)
+                logger.info(f"[{ns}] VM is Running ({len(running)}/{len(namespaces)})")
+                continue
+            # Prefer the VM's printableStatus (e.g. "Provisioning", "Starting",
+            # "WaitingForVolumeBinding") — far more telling than the VMI phase.
+            state = vm_status if vm_status not in ("", "Unknown") else (vmi_phase or "Pending")
+            state_counts[state] = state_counts.get(state, 0) + 1
+            # Surface a likely-stuck VM once, so the user isn't blocked blindly.
+            if ns not in warned and any(h in state.lower() for h in _VM_PROBLEM_HINTS):
+                logger.warning(f"[{ns}] VM in problem state '{state}' — "
+                               f"inspect with: kubectl describe vm {vm_name} -n {ns}")
+                warned.add(ns)
+
+        if len(running) < len(namespaces):
+            elapsed = int(time.time() - start)
+            breakdown = ", ".join(f"{s}={n}" for s, n in sorted(state_counts.items())) or "pending"
+            logger.info(f"  ... {len(running)}/{len(namespaces)} Running after {elapsed}s "
+                        f"(timeout {timeout}s) | remaining: {breakdown}")
+            time.sleep(poll_interval)
+
+    not_running = [ns for ns in namespaces if ns not in running]
+    if not_running:
+        shown = ", ".join(not_running[:10]) + (" ..." if len(not_running) > 10 else "")
+        logger.warning(f"{len(not_running)}/{len(namespaces)} VM(s) not Running after {timeout}s: {shown}")
+    return list(running)
+
+
+def run_cmd(cmd: str, timeout: int = 60) -> Tuple[int, str, str]:
+    """Run shell command and return (returncode, stdout, stderr)."""
+    try:
+        result = subprocess.run(cmd, shell=True, capture_output=True, text=True, timeout=timeout)
+        return result.returncode, result.stdout.strip(), result.stderr.strip()
+    except subprocess.TimeoutExpired:
+        return -1, '', 'Command timed out'
+    except Exception as e:
+        return -1, '', str(e)
+
+
+def get_vm_status(namespace: str, vm_name: str) -> Tuple[str, str]:
+    """Get VM and VMI status. Returns (vm_status, vmi_phase)."""
+    rc, out, _ = run_cmd(f"kubectl get vm {vm_name} -n {namespace} -o jsonpath='{{.status.printableStatus}}'")
+    vm_status = out if rc == 0 else "Unknown"
+
+    rc, out, _ = run_cmd(f"kubectl get vmi {vm_name} -n {namespace} -o jsonpath='{{.status.phase}}'")
+    vmi_phase = out if rc == 0 else "Unknown"
+
+    return vm_status, vmi_phase
+
+
+def discover_vm_name(namespace: str) -> Optional[str]:
+    """Return the name of the (first) VirtualMachine in a namespace, if any.
+
+    Templates may hardcode a VM name instead of honoring {{VM_NAME}}, so the
+    deployed name can differ from --vm-name. This lets the caller adopt the real
+    name rather than waiting for a VM that doesn't exist.
+    """
+    rc, out, _ = run_cmd(f"kubectl get vm -n {namespace} -o jsonpath='{{.items[0].metadata.name}}'")
+    return out if rc == 0 and out else None
+
+
+def get_vm_ip(namespace: str, vm_name: str) -> Optional[str]:
+    """Get VM IP address."""
+    cmd = f"kubectl get vmi {vm_name} -n {namespace} -o jsonpath='{{.status.interfaces[0].ipAddress}}'"
+    rc, out, _ = run_cmd(cmd)
+    return out if rc == 0 and out else None
+
+
+def run_ssh_command(vm_ip: str, command: str, ssh_config: Dict, timeout: int = 60) -> Optional[str]:
+    """
+    Run a command on the VM via the persistent SSH helper pod (password auth).
+
+    Uses the shared ssh_exec_command helper (kubectl exec into the sshpass pod),
+    which is far more reliable than spawning a throwaway pod per call.
+    Returns stripped stdout, or None if the command produced no usable output.
+    """
+    rc, stdout, stderr = ssh_exec_command(
+        vm_ip, command,
+        ssh_config['pod'], ssh_config['pod_ns'],
+        ssh_config['user'], ssh_config['password'],
+        logger=logging.getLogger(__name__),
+        timeout=timeout,
+    )
+    output = (stdout or '').strip()
+    if rc != 0 and not output:
+        logging.getLogger(__name__).debug(
+            f"SSH to {vm_ip} rc={rc}, stderr={(stderr or '').strip()!r}"
+        )
+        return None
+    return output if output else None
+
+
+def create_pvc(namespace: str, pvc_name: str, size: str, storage_class: str) -> bool:
+    """Create a PVC for hotplug/coldplug."""
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+    template_path = os.path.join(script_dir, 'pvc-template.yaml')
+
+    with open(template_path) as f:
+        yaml_content = f.read()
+
+    yaml_content = yaml_content.replace('DISK_NAME', pvc_name)
+    yaml_content = yaml_content.replace('NAMESPACE', namespace)
+    yaml_content = yaml_content.replace('DISK_SIZE', size)
+    yaml_content = yaml_content.replace('STORAGE_CLASS', storage_class)
+
+    result = subprocess.run(
+        ['kubectl', 'apply', '-f', '-'],
+        input=yaml_content.encode(), capture_output=True
+    )
+    return result.returncode == 0
+
+
+def delete_pvc(namespace: str, pvc_name: str) -> bool:
+    """Delete a PVC."""
+    rc, _, _ = run_cmd(f"kubectl delete pvc {pvc_name} -n {namespace} --ignore-not-found")
+    return rc == 0
+
+
+def add_volume(namespace: str, vm_name: str, volume_name: str, pvc_name: str, logger=None) -> Tuple[bool, float, str]:
+    """Add volume to VM using virtctl. Returns (success, time_taken, error_msg)."""
+    start = time.time()
+    # virtctl addvolume expects --volume-name to be the PVC name
+    cmd = f"virtctl addvolume {vm_name} --volume-name={pvc_name} --persist -n {namespace}"
+    rc, out, err = run_cmd(cmd, timeout=60)
+    elapsed = time.time() - start
+    if rc != 0 and logger:
+        logger.error(f"[{namespace}] addvolume failed: {err}")
+    return rc == 0, elapsed, err
+
+
+def remove_volume(namespace: str, vm_name: str, pvc_name: str) -> Tuple[bool, float]:
+    """Remove volume from VM using virtctl. Returns (success, time_taken)."""
+    start = time.time()
+    cmd = f"virtctl removevolume {vm_name} --volume-name={pvc_name} --persist -n {namespace}"
+    rc, _, _ = run_cmd(cmd, timeout=60)
+    elapsed = time.time() - start
+    return rc == 0, elapsed
+
+
+def wait_for_volume_attached(namespace: str, vm_name: str, pvc_name: str, timeout: int = 300) -> Tuple[bool, float]:
+    """Wait for volume to appear in VMI status. Returns (success, time_taken)."""
+    start = time.time()
+    while time.time() - start < timeout:
+        cmd = f"kubectl get vmi {vm_name} -n {namespace} -o jsonpath='{{.status.volumeStatus[*].name}}'"
+        rc, out, _ = run_cmd(cmd)
+        if rc == 0 and pvc_name in out:
+            return True, time.time() - start
+        time.sleep(2)
+    return False, time.time() - start
+
+
+# Block devices that report TYPE=disk but are not attachable storage
+# (e.g. Fedora's zram swap, loopback mounts, optical drives).
+_PSEUDO_DISK_PREFIXES = ('zram', 'loop', 'sr', 'fd')
+
+
+def get_disk_devices(vm_ip: str, ssh_config: Dict) -> Optional[set]:
+    """
+    Return the set of real disk device names in the VM.
+
+    Excludes pseudo devices (zram/loop/sr/fd) so swap and similar don't get
+    miscounted as attached storage. Returns None if the VM couldn't be queried.
+    """
+    output = run_ssh_command(vm_ip, "lsblk -d -n -o NAME,TYPE", ssh_config)
+    if output is None:
+        return None
+    disks = set()
+    for line in output.splitlines():
+        parts = line.split()
+        if len(parts) >= 2 and parts[1] == 'disk' and not parts[0].startswith(_PSEUDO_DISK_PREFIXES):
+            disks.add(parts[0])
+    return disks
+
+
+def get_baseline_disks(vm_ip: str, ssh_config: Dict, logger=None, settle_timeout: int = 60) -> set:
+    """
+    Capture the VM's disk set after it has stabilized.
+
+    Device enumeration (cloud-init disk, zram, etc.) can lag early in boot, so we
+    wait until two consecutive reads agree before trusting the baseline.
+    """
+    start = time.time()
+    previous = None
+    while time.time() - start < settle_timeout:
+        current = get_disk_devices(vm_ip, ssh_config)
+        if current and current == previous:
+            return current
+        previous = current
+        time.sleep(3)
+    return previous or set()
+
+
+def validate_disk_in_vm(vm_ip: str, expected_disks: int, ssh_config: Dict,
+                        baseline_disks: Optional[set] = None, timeout: int = 120,
+                        logger=None) -> Tuple[bool, int, float]:
+    """
+    Validate that the expected number of newly attached disks are visible in the VM.
+
+    Compares the current disk set against the baseline captured before attaching,
+    so only genuinely new devices are counted.
+    Returns (success, new_disk_count, time_taken).
+    """
+    start = time.time()
+    baseline = baseline_disks or set()
+
+    current = get_disk_devices(vm_ip, ssh_config)
+    if current is None:
+        if logger:
+            logger.warning(f"SSH command returned no output for {vm_ip}")
+        return False, 0, time.time() - start
+
+    new_disks = current - baseline
+    if logger:
+        logger.debug(f"Found disks {sorted(current)}, baseline {sorted(baseline)}, "
+                     f"{len(new_disks)} new {sorted(new_disks)} (expected {expected_disks})")
+    success = len(new_disks) >= expected_disks
+    return success, len(new_disks), time.time() - start
+
+
+def stop_vm(namespace: str, vm_name: str, timeout: int = 300) -> bool:
+    """Stop VM and wait for it to be stopped."""
+    run_cmd(f"virtctl stop {vm_name} -n {namespace}")
+    start = time.time()
+    while time.time() - start < timeout:
+        _, vmi_phase = get_vm_status(namespace, vm_name)
+        if vmi_phase == "Unknown" or vmi_phase == "":
+            return True
+        time.sleep(5)
+    return False
+
+
+def start_vm(namespace: str, vm_name: str, timeout: int = 300) -> Tuple[bool, float]:
+    """Start VM and wait for it to be running. Returns (success, boot_time)."""
+    start = time.time()
+    run_cmd(f"virtctl start {vm_name} -n {namespace}")
+
+    while time.time() - start < timeout:
+        _, vmi_phase = get_vm_status(namespace, vm_name)
+        if vmi_phase == "Running":
+            return True, time.time() - start
+        time.sleep(5)
+    return False, time.time() - start
+
+
+def hotplug_disks(namespace: str, vm_name: str, num_disks: int, disk_size: str,
+                  storage_class: str, vm_ip: str, ssh_config: Optional[Dict],
+                  skip_validation: bool, attach_timeout: int,
+                  logger, parallel: bool = False) -> Dict:
+    """Perform hotplug operation on a single VM. If parallel=True, attach all disks concurrently."""
+    result = {
+        "namespace": namespace,
+        "operation": "hotplug",
+        "disks_requested": num_disks,
+        "disks_attached": 0,
+        "disks_validated": 0,
+        "api_attach_time": 0,
+        "volume_ready_time": 0,
+        "validation_time": 0,
+        "total_time": 0,
+        "success": False,
+        "errors": []
+    }
+
+    start_total = time.time()
+    attached_volumes = []
+
+    # Capture the baseline disk set before hotplug (for set-difference validation)
+    baseline_disks = set()
+    if not skip_validation and vm_ip and ssh_config:
+        baseline_disks = get_baseline_disks(vm_ip, ssh_config, logger)
+        logger.debug(f"[{namespace}] Baseline disks: {sorted(baseline_disks)}")
+
+    if parallel:
+        # Parallel hotplug - create all PVCs and add all volumes concurrently
+        import concurrent.futures
+
+        disk_info = []
+        for i in range(num_disks):
+            disk_id = f"{uuid.uuid4().hex[:6]}"
+            disk_info.append({
+                "pvc_name": f"hotplug-disk-{disk_id}",
+                "volume_name": f"hotplug-vol-{disk_id}"
+            })
+
+        # Step 1: Create all PVCs in parallel
+        def create_pvc_task(info):
+            return create_pvc(namespace, info["pvc_name"], disk_size, storage_class), info
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=max(1, num_disks)) as executor:
+            pvc_futures = [executor.submit(create_pvc_task, info) for info in disk_info]
+            valid_disks = []
+            for future in concurrent.futures.as_completed(pvc_futures):
+                success, info = future.result()
+                if success:
+                    valid_disks.append(info)
+                else:
+                    result["errors"].append(f"Failed to create PVC {info['pvc_name']}")
+
+        # Step 2: Add all volumes in parallel
+        def add_volume_task(info):
+            return add_volume(namespace, vm_name, info["volume_name"], info["pvc_name"], logger), info
+
+        api_start = time.time()
+        with concurrent.futures.ThreadPoolExecutor(max_workers=max(1, len(valid_disks))) as executor:
+            vol_futures = [executor.submit(add_volume_task, info) for info in valid_disks]
+            pending_disks = []
+            for future in concurrent.futures.as_completed(vol_futures):
+                (success, api_time, err), info = future.result()
+                if success:
+                    pending_disks.append(info)
+                else:
+                    result["errors"].append(f"Failed to add volume {info['volume_name']}: {err}")
+        result["api_attach_time"] = time.time() - api_start
+
+        # Step 3: Wait for all volumes to be attached in parallel
+        def wait_volume_task(info):
+            return wait_for_volume_attached(namespace, vm_name, info["pvc_name"], attach_timeout), info
+
+        ready_start = time.time()
+        with concurrent.futures.ThreadPoolExecutor(max_workers=max(1, len(pending_disks))) as executor:
+            wait_futures = [executor.submit(wait_volume_task, info) for info in pending_disks]
+            for future in concurrent.futures.as_completed(wait_futures):
+                (success, ready_time), info = future.result()
+                if success:
+                    result["disks_attached"] += 1
+                    attached_volumes.append((info["pvc_name"], info["volume_name"]))
+                else:
+                    result["errors"].append(f"Volume {info['volume_name']} not ready in time")
+        result["volume_ready_time"] = time.time() - ready_start
+    else:
+        # Sequential hotplug - one disk at a time
+        for i in range(num_disks):
+            disk_id = f"{uuid.uuid4().hex[:6]}"
+            pvc_name = f"hotplug-disk-{disk_id}"
+            volume_name = f"hotplug-vol-{disk_id}"
+
+            # Create PVC
+            if not create_pvc(namespace, pvc_name, disk_size, storage_class):
+                result["errors"].append(f"Failed to create PVC {pvc_name}")
+                continue
+
+            # Add volume
+            success, api_time, err = add_volume(namespace, vm_name, volume_name, pvc_name, logger)
+            result["api_attach_time"] += api_time
+
+            if not success:
+                result["errors"].append(f"Failed to add volume {volume_name}: {err}")
+                continue
+
+            # Wait for volume to be attached
+            success, ready_time = wait_for_volume_attached(namespace, vm_name, pvc_name, attach_timeout)
+            result["volume_ready_time"] += ready_time
+
+            if success:
+                result["disks_attached"] += 1
+                attached_volumes.append((pvc_name, volume_name))
+            else:
+                result["errors"].append(f"Volume {volume_name} not ready in time")
+
+    # Validate inside VM (retry to allow disks to appear)
+    if not skip_validation and vm_ip and ssh_config and result["disks_attached"] > 0:
+        max_retries = 3
+        wait_between = 10
+        for attempt in range(1, max_retries + 1):
+            logger.info(f"[{namespace}] Validating {result['disks_attached']} disk(s) inside VM (attempt {attempt}/{max_retries})...")
+            success, disk_count, val_time = validate_disk_in_vm(
+                vm_ip, result["disks_attached"], ssh_config,
+                baseline_disks=baseline_disks, logger=logger
+            )
+            result["validation_time"] += val_time
+            if success:
+                result["disks_validated"] = disk_count
+                break
+            if attempt < max_retries:
+                logger.info(f"[{namespace}] Found {disk_count}/{result['disks_attached']} disks, retrying in {wait_between}s...")
+                time.sleep(wait_between)
+
+        if not success:
+            result["disks_validated"] = 0
+            result["errors"].append(f"Validation failed: expected {result['disks_attached']}, found {disk_count}")
+
+    result["total_time"] = time.time() - start_total
+    result["success"] = (result["disks_attached"] == num_disks and
+                         (skip_validation or result["disks_validated"] >= num_disks))
+    result["attached_volumes"] = attached_volumes
+
+    return result
+
+
+
+def coldplug_disks(namespace: str, vm_name: str, num_disks: int, disk_size: str,
+                   storage_class: str, ssh_config: Optional[Dict], skip_validation: bool,
+                   attach_timeout: int, logger, baseline_disks: Optional[set] = None,
+                   parallel: bool = False) -> Dict:
+    """Perform coldplug operation on a single VM. If parallel=True, attach all disks concurrently."""
+    result = {
+        "namespace": namespace,
+        "operation": "coldplug",
+        "disks_requested": num_disks,
+        "disks_attached": 0,
+        "disks_validated": 0,
+        "api_attach_time": 0,
+        "vm_boot_time": 0,
+        "validation_time": 0,
+        "total_time": 0,
+        "success": False,
+        "errors": []
+    }
+
+    start_total = time.time()
+    attached_volumes = []
+
+    # Capture the baseline disk set before stopping (if not already provided)
+    if not skip_validation and ssh_config and baseline_disks is None:
+        vm_ip = get_vm_ip(namespace, vm_name)
+        if vm_ip:
+            baseline_disks = get_baseline_disks(vm_ip, ssh_config, logger)
+            logger.debug(f"[{namespace}] Baseline disks before coldplug: {sorted(baseline_disks)}")
+
+    # Stop VM first
+    logger.info(f"[{namespace}] Stopping VM for coldplug...")
+    if not stop_vm(namespace, vm_name):
+        result["errors"].append("Failed to stop VM")
+        result["total_time"] = time.time() - start_total
+        return result
+
+    # Attach disks while VM is stopped
+    if parallel:
+        import concurrent.futures
+
+        disk_info = []
+        for i in range(num_disks):
+            disk_id = f"{uuid.uuid4().hex[:6]}"
+            disk_info.append({
+                "pvc_name": f"coldplug-disk-{disk_id}",
+                "volume_name": f"coldplug-vol-{disk_id}"
+            })
+
+        # Create all PVCs in parallel
+        def create_pvc_task(info):
+            return create_pvc(namespace, info["pvc_name"], disk_size, storage_class), info
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=max(1, num_disks)) as executor:
+            pvc_futures = [executor.submit(create_pvc_task, info) for info in disk_info]
+            valid_disks = []
+            for future in concurrent.futures.as_completed(pvc_futures):
+                success, info = future.result()
+                if success:
+                    valid_disks.append(info)
+                else:
+                    result["errors"].append(f"Failed to create PVC {info['pvc_name']}")
+
+        # Add all volumes in parallel
+        def add_volume_task(info):
+            return add_volume(namespace, vm_name, info["volume_name"], info["pvc_name"], logger), info
+
+        api_start = time.time()
+        with concurrent.futures.ThreadPoolExecutor(max_workers=max(1, len(valid_disks))) as executor:
+            vol_futures = [executor.submit(add_volume_task, info) for info in valid_disks]
+            for future in concurrent.futures.as_completed(vol_futures):
+                (success, api_time, err), info = future.result()
+                if success:
+                    result["disks_attached"] += 1
+                    attached_volumes.append((info["pvc_name"], info["volume_name"]))
+                else:
+                    result["errors"].append(f"Failed to add volume {info['volume_name']}: {err}")
+        result["api_attach_time"] = time.time() - api_start
+    else:
+        # Sequential
+        for i in range(num_disks):
+            disk_id = f"{uuid.uuid4().hex[:6]}"
+            pvc_name = f"coldplug-disk-{disk_id}"
+            volume_name = f"coldplug-vol-{disk_id}"
+
+            if not create_pvc(namespace, pvc_name, disk_size, storage_class):
+                result["errors"].append(f"Failed to create PVC {pvc_name}")
+                continue
+
+            success, api_time, err = add_volume(namespace, vm_name, volume_name, pvc_name, logger)
+            result["api_attach_time"] += api_time
+
+            if success:
+                result["disks_attached"] += 1
+                attached_volumes.append((pvc_name, volume_name))
+            else:
+                result["errors"].append(f"Failed to add volume {volume_name}: {err}")
+
+    # Start VM
+    logger.info(f"[{namespace}] Starting VM with {result['disks_attached']} new disks...")
+    success, boot_time = start_vm(namespace, vm_name)
+    result["vm_boot_time"] = boot_time
+
+    if not success:
+        result["errors"].append("Failed to start VM")
+        result["total_time"] = time.time() - start_total
+        return result
+
+    # Validate inside VM (retry to allow disks to appear)
+    if not skip_validation and ssh_config and result["disks_attached"] > 0:
+        vm_ip = wait_for_vm_ip(namespace, vm_name, timeout=120, logger=logger)
+        if vm_ip:
+            logger.info(f"[{namespace}] Waiting for VM to be ready for validation...")
+            time.sleep(10)
+            max_retries = 3
+            wait_between = 10
+            for attempt in range(1, max_retries + 1):
+                logger.info(f"[{namespace}] Validating {result['disks_attached']} disk(s) inside VM (attempt {attempt}/{max_retries})...")
+                success, disk_count, val_time = validate_disk_in_vm(
+                    vm_ip, result["disks_attached"], ssh_config,
+                    baseline_disks=baseline_disks, logger=logger
+                )
+                result["validation_time"] += val_time
+                if success:
+                    result["disks_validated"] = disk_count
+                    break
+                if attempt < max_retries:
+                    logger.info(f"[{namespace}] Found {disk_count}/{result['disks_attached']} disks, retrying in {wait_between}s...")
+                    time.sleep(wait_between)
+
+            if not success:
+                result["disks_validated"] = 0
+
+    result["total_time"] = time.time() - start_total
+    result["success"] = (result["disks_attached"] == num_disks and
+                         (skip_validation or result["disks_validated"] >= num_disks))
+    result["attached_volumes"] = attached_volumes
+
+    return result
+
+
+def unplug_disks(namespace: str, vm_name: str, volumes: List[Tuple[str, str]],
+                 logger) -> Dict:
+    """Remove hotplugged disks. volumes is list of (pvc_name, volume_name)."""
+    result = {
+        "namespace": namespace,
+        "operation": "unplug",
+        "disks_removed": 0,
+        "total_time": 0,
+        "success": False,
+        "errors": []
+    }
+
+    start = time.time()
+
+    for pvc_name, volume_name in volumes:
+        success, _ = remove_volume(namespace, vm_name, pvc_name)
+        if success:
+            result["disks_removed"] += 1
+            # Delete PVC
+            delete_pvc(namespace, pvc_name)
+        else:
+            result["errors"].append(f"Failed to remove {volume_name}")
+
+    result["total_time"] = time.time() - start
+    result["success"] = result["disks_removed"] == len(volumes)
+
+    return result
+
+
+def wait_for_vm_ip(namespace: str, vm_name: str, timeout: int = 120, logger=None) -> Optional[str]:
+    """Wait for VM to get an IP address."""
+    start = time.time()
+    while time.time() - start < timeout:
+        vm_ip = get_vm_ip(namespace, vm_name)
+        if vm_ip:
+            return vm_ip
+        time.sleep(5)
+    return None
+
+
+def process_vm(namespace: str, vm_name: str, args, logger) -> List[Dict]:
+    """Process a single VM for all requested operations."""
+    results = []
+
+    # Get VM status
+    vm_status, vmi_phase = get_vm_status(namespace, vm_name)
+
+    # Wait for VM IP (may take a moment after VM reports Running)
+    vm_ip = None
+    if vmi_phase == "Running":
+        vm_ip = wait_for_vm_ip(namespace, vm_name, timeout=120, logger=logger)
+        if not vm_ip:
+            logger.warning(f"[{namespace}] Could not get VM IP after 120s")
+
+    ssh_config = getattr(args, 'ssh_config', None)
+    logger.info(f"[{namespace}] VM status: {vm_status}, VMI phase: {vmi_phase}, IP: {vm_ip}, validation: {ssh_config is not None}")
+
+    # Hotplug
+    if args.operation in ['hotplug', 'all']:
+        if vmi_phase != "Running":
+            logger.warning(f"[{namespace}] VM not running, skipping hotplug")
+        else:
+            mode = "parallel" if args.parallel_attach else "sequential"
+            logger.info(f"[{namespace}] Starting hotplug of {args.disks} disk(s) ({mode})...")
+            result = hotplug_disks(
+                namespace, vm_name, args.disks, args.disk_size,
+                args.storage_class, vm_ip, ssh_config,
+                args.skip_validation, args.attach_timeout, logger,
+                parallel=args.parallel_attach
+            )
+            results.append(result)
+
+            status = "✓" if result["success"] else "✗"
+            logger.info(f"[{namespace}] Hotplug {status}: {result['disks_attached']}/{args.disks} attached, "
+                       f"time={result['total_time']:.2f}s")
+
+            # Unplug if requested
+            if args.test_unplug and result.get("attached_volumes"):
+                logger.info(f"[{namespace}] Testing unplug...")
+                unplug_result = unplug_disks(namespace, vm_name, result["attached_volumes"], logger)
+                results.append(unplug_result)
+
+    # Coldplug
+    if args.operation in ['coldplug', 'all']:
+        mode = "parallel" if args.parallel_attach else "sequential"
+        logger.info(f"[{namespace}] Starting coldplug of {args.disks} disk(s) ({mode})...")
+        result = coldplug_disks(
+            namespace, vm_name, args.disks, args.disk_size,
+            args.storage_class, ssh_config,
+            args.skip_validation, args.attach_timeout, logger,
+            parallel=args.parallel_attach
+        )
+        results.append(result)
+
+        status = "✓" if result["success"] else "✗"
+        logger.info(f"[{namespace}] Coldplug {status}: {result['disks_attached']}/{args.disks} attached, "
+                   f"boot={result['vm_boot_time']:.2f}s, total={result['total_time']:.2f}s")
+
+        # Unplug if requested
+        if args.test_unplug and result.get("attached_volumes"):
+            logger.info(f"[{namespace}] Testing unplug...")
+            unplug_result = unplug_disks(namespace, vm_name, result["attached_volumes"], logger)
+            results.append(unplug_result)
+
+    return results
+
+
+
+def aggregate_results(all_results: List[Dict], config: Dict) -> Dict:
+    """Aggregate results from all VMs."""
+    hotplug_results = [r for r in all_results if r.get("operation") == "hotplug"]
+    coldplug_results = [r for r in all_results if r.get("operation") == "coldplug"]
+    unplug_results = [r for r in all_results if r.get("operation") == "unplug"]
+
+    def avg(lst, key):
+        vals = [r.get(key, 0) for r in lst if r.get(key)]
+        return round(sum(vals) / len(vals), 3) if vals else 0
+
+    summary = {
+        "test_name": "Disk Operations Benchmark",
+        "timestamp": datetime.now().isoformat(),
+        "config": config,
+        "summary": {
+            "total_vms": len(set(r["namespace"] for r in all_results)),
+            "total_operations": len(all_results),
+        },
+        "hotplug": {
+            "count": len(hotplug_results),
+            "success_count": sum(1 for r in hotplug_results if r["success"]),
+            "total_disks_attached": sum(r.get("disks_attached", 0) for r in hotplug_results),
+            "total_disks_validated": sum(r.get("disks_validated", 0) for r in hotplug_results),
+            "avg_api_attach_time": avg(hotplug_results, "api_attach_time"),
+            "avg_volume_ready_time": avg(hotplug_results, "volume_ready_time"),
+            "avg_validation_time": avg(hotplug_results, "validation_time"),
+            "avg_total_time": avg(hotplug_results, "total_time"),
+        } if hotplug_results else None,
+        "coldplug": {
+            "count": len(coldplug_results),
+            "success_count": sum(1 for r in coldplug_results if r["success"]),
+            "total_disks_attached": sum(r.get("disks_attached", 0) for r in coldplug_results),
+            "total_disks_validated": sum(r.get("disks_validated", 0) for r in coldplug_results),
+            "avg_api_attach_time": avg(coldplug_results, "api_attach_time"),
+            "avg_vm_boot_time": avg(coldplug_results, "vm_boot_time"),
+            "avg_validation_time": avg(coldplug_results, "validation_time"),
+            "avg_total_time": avg(coldplug_results, "total_time"),
+        } if coldplug_results else None,
+        "unplug": {
+            "count": len(unplug_results),
+            "success_count": sum(1 for r in unplug_results if r["success"]),
+            "total_disks_removed": sum(r.get("disks_removed", 0) for r in unplug_results),
+            "avg_total_time": avg(unplug_results, "total_time"),
+        } if unplug_results else None,
+        "per_vm_results": all_results
+    }
+
+    return summary
+
+
+def save_results(results: Dict, results_dir: str, px_version: str, disk_type: str,
+                 vm_start: int, vm_end: int, logger):
+    """Save results to JSON and CSV in the dashboard-compatible folder structure."""
+    timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+    run_name = f"{timestamp}_disk_ops_benchmark_{vm_start}-{vm_end}"
+    folder = os.path.join(results_dir, px_version, disk_type, run_name)
+    os.makedirs(folder, exist_ok=True)
+
+    # Save JSON
+    json_path = os.path.join(folder, "disk_ops_results.json")
+    with open(json_path, 'w') as f:
+        json.dump(results, f, indent=2, default=str)
+    logger.info(f"Results saved to: {json_path}")
+
+    # Save CSV summary
+    csv_path = os.path.join(folder, "disk_ops_summary.csv")
+    with open(csv_path, 'w') as f:
+        f.write("namespace,operation,disks_requested,disks_attached,disks_validated,total_time,success\n")
+        for r in results.get("per_vm_results", []):
+            f.write(f"{r.get('namespace')},{r.get('operation')},{r.get('disks_requested', 0)},"
+                   f"{r.get('disks_attached', 0)},{r.get('disks_validated', 0)},"
+                   f"{r.get('total_time', 0):.2f},{r.get('success')}\n")
+    logger.info(f"CSV saved to: {csv_path}")
+
+    return folder
+
+
+def print_summary(results: Dict, logger):
+    """Print summary table."""
+    print("\n" + "=" * 70)
+    print("DISK OPERATIONS BENCHMARK RESULTS")
+    print("=" * 70)
+
+    if results.get("hotplug"):
+        hp = results["hotplug"]
+        print(f"\nHOTPLUG:")
+        print(f"  Success Rate:      {hp['success_count']}/{hp['count']} ({100*hp['success_count']/hp['count']:.1f}%)")
+        print(f"  Disks Attached:    {hp['total_disks_attached']}")
+        print(f"  Disks Validated:   {hp['total_disks_validated']}")
+        print(f"  Avg API Time:      {hp['avg_api_attach_time']:.2f}s")
+        print(f"  Avg Volume Ready:  {hp['avg_volume_ready_time']:.2f}s")
+        print(f"  Avg Total Time:    {hp['avg_total_time']:.2f}s")
+
+    if results.get("coldplug"):
+        cp = results["coldplug"]
+        print(f"\nCOLDPLUG:")
+        print(f"  Success Rate:      {cp['success_count']}/{cp['count']} ({100*cp['success_count']/cp['count']:.1f}%)")
+        print(f"  Disks Attached:    {cp['total_disks_attached']}")
+        print(f"  Disks Validated:   {cp['total_disks_validated']}")
+        print(f"  Avg API Time:      {cp['avg_api_attach_time']:.2f}s")
+        print(f"  Avg VM Boot Time:  {cp['avg_vm_boot_time']:.2f}s")
+        print(f"  Avg Total Time:    {cp['avg_total_time']:.2f}s")
+
+    if results.get("unplug"):
+        up = results["unplug"]
+        print(f"\nUNPLUG:")
+        print(f"  Success Rate:      {up['success_count']}/{up['count']} ({100*up['success_count']/up['count']:.1f}%)")
+        print(f"  Disks Removed:     {up['total_disks_removed']}")
+        print(f"  Avg Total Time:    {up['avg_total_time']:.2f}s")
+
+    print("=" * 70)
+
+
+def main():
+    args = parse_args()
+    logger = setup_logging(args.log_level, args.log_file)
+
+    created_ssh_pod = False
+    validate = not args.skip_validation
+    # SSH config for the persistent helper pod (only used when validating).
+    ssh_config = {
+        'pod': args.ssh_pod,
+        'pod_ns': args.ssh_pod_ns,
+        'user': args.vm_user,
+        'password': args.vm_password,
+    } if validate else None
+    args.ssh_config = ssh_config
+
+    print("\n" + "=" * 70)
+    print("  DISK OPERATIONS BENCHMARK")
+    print("=" * 70)
+    print(f"  Operation:      {args.operation}")
+    print(f"  Namespaces:     {args.namespace_prefix}-{args.start} to {args.namespace_prefix}-{args.end}")
+    print(f"  Disks per VM:   {args.disks}")
+    print(f"  Disk Size:      {args.disk_size}")
+    print(f"  Storage Class:  {args.storage_class}")
+    print(f"  Create VMs:     {args.create_vms}")
+    print(f"  Concurrency:    {args.concurrency}")
+    print(f"  VM User:        {args.vm_user}")
+    print(f"  Validation:     {'Enabled (SSH via ' + args.ssh_pod_ns + '/' + args.ssh_pod + ')' if validate else 'Skip'}")
+    print(f"  Test Unplug:    {'Yes' if args.test_unplug else 'No'}")
+    print("=" * 70 + "\n")
+
+    # Generate namespace list
+    namespaces = [f"{args.namespace_prefix}-{i}" for i in range(args.start, args.end + 1)]
+
+    try:
+        # Ensure the persistent SSH helper pod exists when validation is enabled.
+        if validate:
+            ready, created_ssh_pod = ensure_ssh_pod(args.ssh_pod, args.ssh_pod_ns, logger)
+            if not ready:
+                logger.error("SSH helper pod unavailable; re-run with --skip-validation "
+                             "to proceed without in-VM checks")
+                sys.exit(1)
+
+        if args.create_vms:
+            # Step 1: Create namespaces
+            print("[1/3] Creating namespaces...")
+            for ns in namespaces:
+                create_namespace(ns)
+
+            # Step 2: Deploy VMs
+            print("[2/3] Deploying VMs...")
+            template_path = args.vm_template
+            if not os.path.isabs(template_path):
+                script_dir = os.path.dirname(os.path.abspath(__file__))
+                template_path = os.path.join(script_dir, template_path)
+            if not os.path.exists(template_path):
+                logger.error(f"VM template not found: {template_path}")
+                sys.exit(1)
+            vm_yaml = prepare_vm_yaml(template_path, args.vm_name, args.storage_class, args.vm_password)
+
+            # Fail fast on placeholders we couldn't fill, instead of shipping broken
+            # YAML to every namespace and then waiting for VMs that never deploy.
+            leftover = sorted(set(re.findall(r'\{\{[^}]+\}\}', vm_yaml)))
+            if leftover:
+                logger.error(f"VM template '{template_path}' has unsubstituted placeholders: {', '.join(leftover)}")
+                logger.error("Supported: {{VM_NAME}}, {{STORAGE_CLASS}} (or {{STORAGE_CLASS_NAME}}), {{VM_PASSWORD}}. "
+                             "Use a disk-ops-compatible template (see disk-ops-benchmark/vm-template.yaml).")
+                sys.exit(1)
+
+            deployed = []
+            with ThreadPoolExecutor(max_workers=max(1, args.concurrency)) as executor:
+                futures = {executor.submit(deploy_vm, ns, vm_yaml, logger): ns for ns in namespaces}
+                for future in as_completed(futures):
+                    ns = futures[future]
+                    if future.result():
+                        deployed.append(ns)
+
+            # Don't proceed to the wait/operations if deploys failed.
+            if not deployed:
+                logger.error(f"All {len(namespaces)} VM deploy(s) failed; aborting. "
+                             "Check the template, storage class, and cluster state above.")
+                sys.exit(1)
+            if len(deployed) < len(namespaces):
+                logger.warning(f"{len(namespaces) - len(deployed)}/{len(namespaces)} VM deploy(s) failed; "
+                               f"continuing with the {len(deployed)} that deployed.")
+            namespaces = deployed
+
+            # A template may hardcode a VM name instead of honoring {{VM_NAME}}
+            # (e.g. rhel9-vm-datasource.yaml names its VM 'rhel-9-vm'). Adopt the
+            # actual deployed name so we don't wait for a VM that was never created.
+            actual_vm = discover_vm_name(deployed[0])
+            if not actual_vm:
+                logger.error(f"No VirtualMachine found in '{deployed[0]}' after deploy; aborting.")
+                sys.exit(1)
+            if actual_vm != args.vm_name:
+                logger.warning(f"Template created VM named '{actual_vm}', not --vm-name '{args.vm_name}'. "
+                               f"Using '{actual_vm}' (tip: give the template a {{{{VM_NAME}}}} "
+                               f"placeholder to honor --vm-name).")
+                args.vm_name = actual_vm
+
+            # Step 3: Wait for VMs to be Running
+            print("[3/3] Waiting for VMs to be Running...")
+            running_namespaces = wait_for_vms_running(namespaces, args.vm_name, args.vm_timeout, logger)
+
+            if len(running_namespaces) < len(namespaces):
+                logger.warning(f"Only {len(running_namespaces)}/{len(namespaces)} VMs are running")
+
+            namespaces = running_namespaces
+
+        # Process VMs in parallel
+        print("\nRunning disk operations...")
+        all_results = []
+
+        with ThreadPoolExecutor(max_workers=args.concurrency) as executor:
+            futures = {
+                executor.submit(process_vm, ns, args.vm_name, args, logger): ns
+                for ns in namespaces
+            }
+
+            for future in as_completed(futures):
+                ns = futures[future]
+                try:
+                    results = future.result()
+                    all_results.extend(results)
+                except Exception as e:
+                    logger.error(f"[{ns}] Error processing VM: {e}")
+
+        # Aggregate results
+        config = {
+            "operation": args.operation,
+            "disks_per_vm": args.disks,
+            "disk_size": args.disk_size,
+            "storage_class": args.storage_class,
+            "test_unplug": args.test_unplug,
+            "skip_validation": args.skip_validation,
+            "create_vms": args.create_vms
+        }
+
+        aggregated = aggregate_results(all_results, config)
+
+        # Print summary
+        print_summary(aggregated, logger)
+
+        # Save results
+        if args.save_results:
+            disk_type = args.disk_type or f"{args.disks}-disk"
+            save_results(aggregated, args.results_dir, args.px_version, disk_type,
+                        args.start, args.end, logger)
+
+        # Cleanup if requested
+        if args.cleanup:
+            logger.info("\nCleaning up hotplugged disks...")
+            for result in all_results:
+                if result.get("attached_volumes"):
+                    for pvc_name, volume_name in result["attached_volumes"]:
+                        ns = result["namespace"]
+                        remove_volume(ns, args.vm_name, pvc_name)
+                        delete_pvc(ns, pvc_name)
+
+            # Cleanup VMs and namespaces if we created them
+            if args.create_vms:
+                logger.info("Cleaning up VMs and namespaces...")
+                for ns in namespaces:
+                    run_cmd(f"kubectl delete vm {args.vm_name} -n {ns} --ignore-not-found")
+                    run_cmd(f"kubectl delete namespace {ns} --ignore-not-found")
+
+            logger.info("Cleanup complete")
+
+    finally:
+        # Remove the SSH helper pod only if we created it and cleanup was requested.
+        if created_ssh_pod and args.cleanup:
+            logger.info(f"Removing SSH helper pod {args.ssh_pod_ns}/{args.ssh_pod}")
+            run_cmd(f"kubectl delete pod {args.ssh_pod} -n {args.ssh_pod_ns} --ignore-not-found")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/reference/user-guide/repository-structure.md
+++ b/docs/reference/user-guide/repository-structure.md
@@ -12,6 +12,7 @@ kubevirt-benchmark/
 │   ├── commands/                 # Individual command implementations
 │   │   ├── chaos.py              # Chaos benchmark
 │   │   ├── datasource_clone.py   # DataSource clone benchmark
+│   │   ├── disk_ops.py           # Disk hotplug/coldplug benchmark
 │   │   ├── elbencho.py           # elbencho IO benchmark
 │   │   ├── failure_recovery.py   # Failure recovery benchmark
 │   │   ├── fio.py                # FIO IO benchmark
@@ -25,6 +26,8 @@ kubevirt-benchmark/
 │   └── measure-chaos.py
 ├── datasource-clone/             # DataSource-clone benchmark Python script
 │   └── measure-vm-creation-time.py
+├── disk-ops-benchmark/           # Disk hotplug/coldplug benchmark
+│   ├── measure-disk-ops.py
 ├── migration/                    # Migration benchmark Python script
 │   └── measure-vm-migration-time.py
 ├── failure-recovery/             # Failure-recovery Python script and FAR template

--- a/docs/reference/user-guide/test-scenarios/cluster-validation.md
+++ b/docs/reference/user-guide/test-scenarios/cluster-validation.md
@@ -13,7 +13,7 @@ The script validates:
   - virt-handler daemonset on all nodes
 - Storage class availability
 - Worker node readiness
-- DataSource availability
+- DataSource availability (optional — only needed for datasource-clone and chaos tests)
 - User permissions
 - Node resource utilization
 
@@ -85,13 +85,17 @@ Cluster validation passed! Ready to run benchmarks.
 ✓ kubectl access and cluster connectivity
 ✗ OpenShift Virtualization not found or not healthy
   - KubeVirt resource not in Deployed phase
-✓ Storage class available
+✗ Storage class 'YOUR-STORAGE-CLASS' not found
 ✓ Worker nodes ready (3 nodes)
-✗ DataSource 'rhel9' not found
-  - Check namespace: openshift-virtualization-os-images
+⚠ DataSource 'rhel9' exists but is not ready - WARNING (only needed for datasource-clone/chaos tests)
 
 Cluster validation failed. Please fix the issues above.
 ```
+
+A missing or not-ready DataSource is reported as a **warning**, not a failure — it
+only blocks the datasource-clone and chaos tests. Validation fails only on the
+hard checks above (connectivity, virtualization, storage class, worker nodes,
+permissions).
 
 ## Troubleshooting Validation Failures
 
@@ -181,7 +185,7 @@ Before running benchmarks, ensure:
 - [ ] Storage class is compatible with KubeVirt DataVolumes
 - [ ] SSH test pod is running (for network tests)
 - [ ] Sufficient cluster resources available
-- [ ] DataSource exists and is ready
+- [ ] DataSource exists and is ready (only for datasource-clone / chaos tests)
 
 ## See Also
 

--- a/docs/reference/user-guide/test-scenarios/disk-ops-benchmark.md
+++ b/docs/reference/user-guide/test-scenarios/disk-ops-benchmark.md
@@ -1,0 +1,186 @@
+# Disk Operations Benchmark
+
+Tests disk hotplug and coldplug performance for KubeVirt VMs.
+
+**Use Case**: Measure disk attach/detach times for running and stopped VMs with in-VM validation.
+
+## Operations
+
+| Operation | Description | VM State |
+|-----------|-------------|----------|
+| `hotplug` | Attach disk to running VM | Running |
+| `coldplug` | Attach disk to stopped VM, then start | Stopped |
+| `all` | Run both hotplug and coldplug | Both |
+
+## Basic Usage
+
+### virtbench CLI
+
+```bash
+# Create VMs and hotplug 3 disks
+virtbench disk-ops --start 1 --end 10 --storage-class px-csi --disks 3 \
+  --create-vms --save-results
+
+# Coldplug test (creates VMs, stops them, attaches disk, starts them)
+virtbench disk-ops --start 1 --end 5 --storage-class px-csi \
+  --operation coldplug --create-vms --save-results
+
+# All operations with unplug test and cleanup
+virtbench disk-ops --start 1 --end 10 --storage-class px-csi \
+  --operation all --create-vms --test-unplug --cleanup
+```
+
+### Python Script
+
+```bash
+cd disk-ops-benchmark
+
+python3 measure-disk-ops.py \
+  --start 1 --end 10 \
+  --storage-class px-csi \
+  --operation hotplug \
+  --disks 3 \
+  --create-vms \
+  --save-results
+```
+
+## Validation Modes
+
+In-VM validation runs `lsblk` over SSH to confirm each disk is visible inside the
+guest. SSH goes through a **persistent helper pod** (`--ssh-pod`, default
+`ssh-test-pod` in the `default` namespace) that has `sshpass` installed — the pod
+is auto-created if it doesn't exist and reused across runs. Authentication is
+password-based (`--vm-user` / `--vm-password`).
+
+- **`--create-vms`** — VMs are provisioned with `--vm-password` baked into their
+  cloud-init, so validation works out of the box.
+- **Pre-existing VMs** — pass `--vm-user` / `--vm-password` matching the password
+  those VMs already accept (and ensure their `sshd` allows password auth).
+- **`--skip-validation`** — skip the in-VM SSH check entirely and rely only on
+  API-level volume status. No helper pod is created.
+
+## Configuration Options
+
+### Operation Settings
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--start` | (required) | Start namespace index |
+| `--end` | (required) | End namespace index |
+| `--storage-class` | (required) | Storage class for PVCs |
+| `--operation` | `all` | Operation: `hotplug`, `coldplug`, `all` |
+| `--disks` | `1` | Number of disks per VM |
+| `--disk-size` | `10Gi` | Disk size |
+| `--test-unplug` | `false` | Also test disk removal |
+
+### VM Settings
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--namespace-prefix` | `disk-ops` | Namespace prefix |
+| `--vm-name` | `disk-ops-vm` | VM name |
+| `--vm-template` | `disk-ops-benchmark/vm-template.yaml` | VM template file (used with `--create-vms`) |
+| `--vm-user` | `cloud-user` | VM SSH user for in-VM validation |
+| `--vm-password` | `changeme` | VM SSH password for in-VM validation |
+| `--ssh-pod` | `ssh-test-pod` | Persistent SSH helper pod with `sshpass` (auto-created if missing) |
+| `--ssh-pod-ns` | `default` | SSH helper pod namespace |
+| `--create-vms` | `false` | Create VMs before testing |
+
+### Execution Settings
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--concurrency` | `10` | Max concurrent operations |
+| `--attach-timeout` | `300` | Disk attach timeout (seconds) |
+| `--skip-validation` | `false` | Skip in-VM validation |
+
+### Output Settings
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--results-dir` | `results` | Base results directory |
+| `--save-results` | `false` | Save results to JSON/CSV |
+| `--px-version` | `px-unknown` | Storage driver/version label for the results folder |
+| `--disk-type` | `1-disk` | Disk type label for the results folder |
+| `--cleanup` | `false` | Remove hotplugged disks (and created VMs) after test |
+
+## Metrics
+
+### Hotplug Metrics
+
+| Metric | Description |
+|--------|-------------|
+| `api_attach_time` | Time for `virtctl addvolume` API call |
+| `volume_ready_time` | Time for volume to appear in VMI status |
+| `validation_time` | Time to verify disk in VM via SSH |
+| `total_time` | End-to-end hotplug time |
+
+### Coldplug Metrics
+
+| Metric | Description |
+|--------|-------------|
+| `api_attach_time` | Time to attach disk to stopped VM |
+| `vm_boot_time` | Time for VM to boot with new disk |
+| `validation_time` | Time to verify disk in VM via SSH |
+| `total_time` | End-to-end coldplug time |
+
+## Validation
+
+The benchmark validates disk attachment at two levels:
+
+1. **API Level**: Checks volume appears in `vmi.status.volumeStatus`
+2. **VM Level**: SSH into VM and verify disk via `lsblk`
+
+Validation ensures the disk is actually usable inside the VM, not just attached at the API level.
+
+## Results
+
+### Output Structure
+
+```
+results/{px-version}/{disk-type}/{timestamp}_disk_ops_benchmark_{start}-{end}/
+├── disk_ops_results.json    # Full results with per-VM data
+└── disk_ops_summary.csv     # CSV summary
+```
+
+The `{px-version}` and `{disk-type}` segments come from `--px-version` and
+`--disk-type`, keeping the layout compatible with the results dashboard.
+
+### Sample Output
+
+```
+======================================================================
+DISK OPERATIONS BENCHMARK RESULTS
+======================================================================
+
+HOTPLUG:
+  Success Rate:      10/10 (100.0%)
+  Disks Attached:    30
+  Disks Validated:   30
+  Avg API Time:      1.25s
+  Avg Volume Ready:  3.50s
+  Avg Total Time:    7.20s
+
+COLDPLUG:
+  Success Rate:      10/10 (100.0%)
+  Disks Attached:    30
+  Disks Validated:   30
+  Avg API Time:      0.80s
+  Avg VM Boot Time:  45.00s
+  Avg Total Time:    52.30s
+======================================================================
+```
+
+### View in Dashboard
+
+```bash
+cd dashboard
+python3 generate_dashboard.py --base-dir ../results
+open output/dashboard.html
+```
+
+The dashboard shows:
+- KPI cards (Hotplug/Coldplug avg time, success rate)
+- Time breakdown chart (API, Volume Ready/Boot, Validation)
+- Per-VM results table with validation status
+

--- a/docs/reference/user-guide/test-scenarios/overview.md
+++ b/docs/reference/user-guide/test-scenarios/overview.md
@@ -72,6 +72,15 @@ for larger test plans.
 
 [Learn more →](vm-ops/overview.md)
 
+### 10. Disk Operations (Hotplug/Coldplug)
+Tests disk hotplug (attach to running VM) and coldplug (attach to stopped VM,
+then boot) performance, with optional in-VM validation that the disk appears.
+
+**Use Case**: Measure disk attach/detach times and verify disks become usable
+inside running and stopped VMs.
+
+[Learn more →](disk-ops-benchmark.md)
+
 ## Next Steps
 
 1. [Configure your environment](../configuration.md) - Set up storage classes and templates

--- a/io-benchmark/fio/measure-fio-performance.py
+++ b/io-benchmark/fio/measure-fio-performance.py
@@ -620,42 +620,24 @@ def action_gather_results(args, namespaces, fio_config, ssh_config, logger):
 
     all_results = []
 
-    # Use SSH via existing pod (password-based)
-    for ns in namespaces:
-        vm_ip = get_vmi_ip(args.vm_name, ns, logger)
-        if not vm_ip:
-            print(f"  ✗ {ns}: Could not get VM IP")
-            all_results.append({"namespace": ns, "success": False})
-            continue
-
-        # Try to get FIO results
-        output = run_ssh_command(
-            vm_ip, 'cat /tmp/fio_results.json',
-            ssh_config['pod'], ssh_config['pod_ns'],
-            ssh_config['user'], ssh_config['password'],
-            timeout=120
-        )
-
-        if output:
-            json_content = extract_json_object(output)
-            if json_content:
-                try:
-                    raw_data = json.loads(json_content)
-                    # Save raw data
-                    vm_results_dir = os.path.join(output_dir, "per-vm-results", ns)
-                    os.makedirs(vm_results_dir, exist_ok=True)
-                    with open(os.path.join(vm_results_dir, "fio_raw.json"), 'w') as f:
-                        f.write(json_content)
-
-                    parsed = parse_fio_results(ns, raw_data)
-                    all_results.append(parsed)
-                    print(f"  ✓ {ns}")
-                    continue
-                except json.JSONDecodeError:
-                    pass
-
-        print(f"  ✗ {ns}: No valid results")
-        all_results.append({"namespace": ns, "success": False})
+    # Collect from all VMs concurrently (honors --collect-concurrency), reusing the
+    # same retrying collector as the run-all workflow.
+    with ThreadPoolExecutor(max_workers=max(1, args.collect_concurrency)) as executor:
+        futures = {
+            executor.submit(
+                collect_fio_results, ns, args.vm_name, ssh_config, output_dir, logger,
+                args.collect_retries, args.collect_retry_delay
+            ): ns for ns in namespaces
+        }
+        for future in as_completed(futures):
+            ns = futures[future]
+            raw_data = future.result()
+            if raw_data:
+                all_results.append(parse_fio_results(ns, raw_data))
+                print(f"  ✓ {ns}")
+            else:
+                all_results.append({"namespace": ns, "success": False})
+                print(f"  ✗ {ns}")
 
     # Aggregate and save
     test_duration = time.time() - test_start

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -42,6 +42,7 @@ nav:
           - Cluster Validation: reference/user-guide/test-scenarios/cluster-validation.md
           - FIO Benchmark: reference/user-guide/test-scenarios/fio-benchmark.md
           - Elbencho Benchmark: reference/user-guide/test-scenarios/elbencho-benchmark.md
+          - Disk Operations (Hotplug/Coldplug): reference/user-guide/test-scenarios/disk-ops-benchmark.md
           - VM Operations:
               - Overview: reference/user-guide/test-scenarios/vm-ops/overview.md
               - Drain Nodes: reference/user-guide/test-scenarios/vm-ops/drain-nodes.md

--- a/utils/validate_cluster.py
+++ b/utils/validate_cluster.py
@@ -224,22 +224,31 @@ class ClusterValidator:
         return True, f"Node resources look healthy ({len(lines)} nodes checked)"
     
     def check_datasource(self, datasource_name: str, namespace: str) -> Tuple[bool, str]:
-        """Verify DataSource exists"""
+        """Verify a DataSource exists and is ready.
+
+        Non-fatal: a DataSource is only required by tests that clone from it
+        (datasource-clone, chaos). Other workloads (fio, disk-ops, elbencho) boot
+        from container-disk images, so a missing or not-ready DataSource is a
+        warning rather than a cluster-validation failure.
+        """
+        suffix = "WARNING (only needed for datasource-clone/chaos tests)"
         returncode, stdout, stderr = run_kubectl_command(
             ['get', 'datasource', datasource_name, '-n', namespace, '-o', 'json'],
             check=False,
             logger=self.logger
         )
         if returncode != 0:
-            return False, f"DataSource '{datasource_name}' not found in namespace '{namespace}'"
-        
+            self.warnings += 1
+            return True, f"DataSource '{datasource_name}' not found in namespace '{namespace}' - {suffix}"
+
         data = json.loads(stdout)
         conditions = data.get('status', {}).get('conditions', [])
         ready = any(c.get('type') == 'Ready' and c.get('status') == 'True' for c in conditions)
-        
+
         if ready:
             return True, f"DataSource '{datasource_name}' is ready in namespace '{namespace}'"
-        return False, f"DataSource '{datasource_name}' exists but is not ready"
+        self.warnings += 1
+        return True, f"DataSource '{datasource_name}' exists but is not ready - {suffix}"
     
     def check_ssh_pod(self, pod_name: str, namespace: str) -> Tuple[bool, str]:
         """Verify SSH test pod exists and is running"""

--- a/virtbench/cli.py
+++ b/virtbench/cli.py
@@ -18,6 +18,7 @@ from virtbench.commands import (
     failure_recovery,
     fio,
     elbencho,
+    disk_ops,
     validate,
     version,
     vm_ops,
@@ -77,6 +78,7 @@ def cli(ctx, log_level, log_file, kubeconfig, timeout, uuid):
       failure-recovery     Run failure recovery benchmark
       fio                  Run FIO benchmark across VMs
       elbencho             Manage elbencho workloads on VMs
+      disk-ops             Run disk hotplug/coldplug benchmark
       vm-ops               VM operations (drain, rebalance, snapshot, blkdiscard, power)
       validate-cluster     Validate cluster prerequisites
       version              Print version information
@@ -127,6 +129,7 @@ cli.add_command(chaos.chaos_benchmark)
 cli.add_command(failure_recovery.failure_recovery)
 cli.add_command(fio.fio)
 cli.add_command(elbencho.elbencho)
+cli.add_command(disk_ops.disk_ops)
 cli.add_command(vm_ops.vm_ops)
 cli.add_command(validate.validate_cluster)
 cli.add_command(version.version)

--- a/virtbench/commands/disk_ops.py
+++ b/virtbench/commands/disk_ops.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""
+Disk Operations Benchmark command - Hotplug/Coldplug disk performance testing
+"""
+import click
+import subprocess
+import sys
+from pathlib import Path
+from rich.console import Console
+
+from virtbench.common import print_banner, build_python_command, generate_log_filename
+
+console = Console()
+
+
+@click.command('disk-ops')
+@click.option('--start', '-s', required=True, type=int, help='Start namespace index')
+@click.option('--end', '-e', required=True, type=int, help='End namespace index')
+@click.option('--storage-class', required=True, help='Storage class for PVCs')
+@click.option('--operation', default='all', type=click.Choice(['hotplug', 'coldplug', 'all']),
+              help='Operation type (default: all)')
+@click.option('--disks', default=1, type=int, help='Number of disks per VM')
+@click.option('--disk-size', default='10Gi', help='Disk size')
+@click.option('--parallel-attach', is_flag=True,
+              help='Attach all disks in parallel (default: sequential)')
+@click.option('--namespace-prefix', default='disk-ops', help='Namespace prefix')
+@click.option('--vm-name', default='disk-ops-vm', help='VM name')
+@click.option('--vm-template', default='disk-ops-benchmark/vm-template.yaml',
+              help='Path to VM template YAML (used with --create-vms)')
+@click.option('--vm-user', default='cloud-user', help='VM SSH user for in-VM validation')
+@click.option('--vm-password', default='changeme', help='VM SSH password for in-VM validation')
+@click.option('--ssh-pod', default='ssh-test-pod',
+              help='Persistent SSH helper pod with sshpass (auto-created if missing)')
+@click.option('--ssh-pod-ns', default='default', help='SSH helper pod namespace')
+@click.option('--create-vms', is_flag=True, help='Create VMs before testing')
+@click.option('--concurrency', '-c', default=10, type=int, help='Max concurrent operations')
+@click.option('--attach-timeout', default=300, type=int, help='Disk attach timeout (seconds)')
+@click.option('--vm-timeout', default=600, type=int,
+              help='Timeout for created VMs to reach Running, incl. image import (seconds)')
+@click.option('--test-unplug', is_flag=True, help='Also test disk removal')
+@click.option('--skip-validation', is_flag=True, help='Skip in-VM validation')
+@click.option('--results-dir', default='results', help='Base directory for results')
+@click.option('--save-results', is_flag=True, help='Save results to JSON/CSV files')
+@click.option('--px-version', default='px-unknown', help='Storage driver/version label for results folder')
+@click.option('--disk-type', default=None, help='Disk type label for results folder (default: <disks>-disk)')
+@click.option('--cleanup', is_flag=True, help='Remove hotplugged disks (and created VMs) after test')
+@click.option('--log-file', type=click.Path(), help='Log file path (auto-generated if not specified)')
+@click.option('--log-level', default='INFO',
+              type=click.Choice(['DEBUG', 'INFO', 'WARNING', 'ERROR']),
+              help='Logging level')
+@click.pass_context
+def disk_ops(ctx, **kwargs):
+    """
+    Run disk operations benchmark (hotplug/coldplug)
+
+    Measures the time to attach disks to running VMs (hotplug) or stopped VMs
+    (coldplug), with optional in-VM validation to verify disks appear correctly.
+
+    \b
+    Operations:
+      hotplug  - Attach disk to running VM
+      coldplug - Attach disk to stopped VM, then start
+      all      - Run both hotplug and coldplug tests (default)
+
+    \b
+    Validation:
+      In-VM validation runs lsblk over SSH through a persistent helper pod
+      (--ssh-pod, auto-created with sshpass if missing) using password auth
+      (--vm-user/--vm-password). With --create-vms the VMs are provisioned with
+      that password baked in. Use --skip-validation to skip the SSH checks.
+
+    \b
+    Examples:
+      # Create VMs and hotplug 3 disks to each
+      virtbench disk-ops --start 1 --end 10 --storage-class px-csi --disks 3 \\
+          --create-vms --save-results
+    \b
+      # Coldplug against existing VMs (must already trust --vm-password)
+      virtbench disk-ops --start 1 --end 5 --storage-class px-csi \\
+          --operation coldplug --vm-password mypass --save-results
+    \b
+      # All operations with unplug test and cleanup
+      virtbench disk-ops --start 1 --end 10 --storage-class px-csi \\
+          --operation all --create-vms --test-unplug --cleanup
+    """
+    print_banner("Disk Operations Benchmark")
+
+    repo_root = ctx.obj.repo_root
+    script_path = repo_root / 'disk-ops-benchmark' / 'measure-disk-ops.py'
+
+    if not script_path.exists():
+        console.print(f"[red]Error:[/red] Script not found: {script_path}")
+        sys.exit(1)
+
+    # Resolve VM template path relative to repo root (only needed for --create-vms)
+    vm_template_path = Path(kwargs['vm_template']).expanduser()
+    if not vm_template_path.is_absolute():
+        vm_template_path = repo_root / vm_template_path
+
+    if kwargs['create_vms'] and not vm_template_path.exists():
+        console.print(f"[red]Error:[/red] VM template not found: {vm_template_path}")
+        sys.exit(1)
+
+    console.print(f"[cyan]Operation:[/cyan] {kwargs['operation']}  "
+                  f"[cyan]Storage class:[/cyan] {kwargs['storage_class']}  "
+                  f"[cyan]Disks/VM:[/cyan] {kwargs['disks']}")
+
+    # Map CLI args to the benchmark script's arguments
+    python_args = {
+        'start': kwargs['start'],
+        'end': kwargs['end'],
+        'storage-class': kwargs['storage_class'],
+        'operation': kwargs['operation'],
+        'disks': kwargs['disks'],
+        'disk-size': kwargs['disk_size'],
+        'namespace-prefix': kwargs['namespace_prefix'],
+        'vm-name': kwargs['vm_name'],
+        'vm-template': str(vm_template_path),
+        'vm-user': kwargs['vm_user'],
+        'vm-password': kwargs['vm_password'],
+        'ssh-pod': kwargs['ssh_pod'],
+        'ssh-pod-ns': kwargs['ssh_pod_ns'],
+        'concurrency': kwargs['concurrency'],
+        'attach-timeout': kwargs['attach_timeout'],
+        'vm-timeout': kwargs['vm_timeout'],
+        'results-dir': kwargs['results_dir'],
+        'px-version': kwargs['px_version'],
+        'disk-type': kwargs['disk_type'],
+        'log-level': kwargs['log_level'],
+    }
+
+    # Log file: explicit > global context > auto-generated timestamped file
+    if kwargs.get('log_file'):
+        python_args['log-file'] = kwargs['log_file']
+    elif ctx.obj.log_file:
+        python_args['log-file'] = ctx.obj.log_file
+    else:
+        python_args['log-file'] = generate_log_filename('disk-ops-benchmark')
+
+    # Flags
+    if kwargs['parallel_attach']:
+        python_args['parallel-attach'] = True
+    if kwargs['create_vms']:
+        python_args['create-vms'] = True
+    if kwargs['test_unplug']:
+        python_args['test-unplug'] = True
+    if kwargs['skip_validation']:
+        python_args['skip-validation'] = True
+    if kwargs['save_results']:
+        python_args['save-results'] = True
+    if kwargs['cleanup']:
+        python_args['cleanup'] = True
+
+    cmd = build_python_command(script_path, python_args)
+
+    console.print(f"[dim]Running: {' '.join(cmd[:2])} ...[/dim]")
+    console.print()
+
+    try:
+        result = subprocess.run(cmd, cwd=repo_root)
+        sys.exit(result.returncode)
+    except KeyboardInterrupt:
+        console.print("\n[yellow]Interrupted by user[/yellow]")
+        sys.exit(130)
+    except Exception as e:
+        console.print(f"[red]Error:[/red] {e}")
+        sys.exit(1)


### PR DESCRIPTION


**What this PR does / why we need it**:

This PR Adds Supports for disk operations hotplug,coldplug and also validates the disks attached inside the VM and also it has capability to measure the time taken to detach the disk as well





Testing Done:

```
sayalasomayajula@sayalasomayajula--Mac15 vm-templates % virtbench disk-ops --start 1 --end 1 --storage-class px-fa-direct-access --disks 3 --create-vms --vm-template /Users/sayalasomayajula/kubevirt-benchmark/examples/vm-templates/rhel9-vm-datasource.yaml --test-unplug

================================================================================
  Disk Operations Benchmark
================================================================================

Operation: all  Storage class: px-fa-direct-access  Disks/VM: 3
Running: /Library/Developer/CommandLineTools/usr/bin/python3 /Users/sayalasomayajula/kubevirt-benchmark/disk-ops-benchmark/measure-disk-ops.py ...


======================================================================
  DISK OPERATIONS BENCHMARK
======================================================================
  Operation:      all
  Namespaces:     disk-ops-1 to disk-ops-1
  Disks per VM:   3
  Disk Size:      10Gi
  Storage Class:  px-fa-direct-access
  Create VMs:     True
  Concurrency:    10
  VM User:        cloud-user
  Validation:     Enabled (SSH via default/ssh-test-pod)
  Test Unplug:    Yes
======================================================================

2026-06-16 10:06:30 - INFO - Using existing SSH helper pod default/ssh-test-pod
[1/3] Creating namespaces...
[2/3] Deploying VMs...
2026-06-16 10:06:33 - INFO - [disk-ops-1] VM deployed
2026-06-16 10:06:34 - WARNING - Template created VM named 'rhel-9-vm', not --vm-name 'disk-ops-vm'. Using 'rhel-9-vm' (tip: give the template a {{VM_NAME}} placeholder to honor --vm-name).
[3/3] Waiting for VMs to be Running...
2026-06-16 10:06:34 - INFO - Waiting for 1 VMs to be Running (timeout: 600s)...
2026-06-16 10:06:37 - INFO -   ... 0/1 Running after 2s (timeout 600s) | remaining: Starting=1
2026-06-16 10:06:48 - INFO - [disk-ops-1] VM is Running (1/1)

Running disk operations...
2026-06-16 10:06:51 - INFO - [disk-ops-1] VM status: Running, VMI phase: Running, IP: 172.201.24.112, validation: True
2026-06-16 10:06:51 - INFO - [disk-ops-1] Starting hotplug of 3 disk(s) (sequential)...
2026-06-16 10:07:24 - INFO - [disk-ops-1] Validating 3 disk(s) inside VM (attempt 1/3)...
2026-06-16 10:07:27 - INFO - [disk-ops-1] Found 1/3 disks, retrying in 10s...
2026-06-16 10:07:37 - INFO - [disk-ops-1] Validating 3 disk(s) inside VM (attempt 2/3)...
2026-06-16 10:07:41 - INFO - [disk-ops-1] Hotplug ✓: 3/3 attached, time=50.01s
2026-06-16 10:07:41 - INFO - [disk-ops-1] Testing unplug...
2026-06-16 10:07:49 - INFO - [disk-ops-1] Starting coldplug of 3 disk(s) (sequential)...
2026-06-16 10:08:01 - INFO - [disk-ops-1] Stopping VM for coldplug...
2026-06-16 10:08:22 - INFO - [disk-ops-1] Starting VM with 3 new disks...
2026-06-16 10:08:40 - INFO - [disk-ops-1] Waiting for VM to be ready for validation...
2026-06-16 10:08:50 - INFO - [disk-ops-1] Validating 3 disk(s) inside VM (attempt 1/3)...
2026-06-16 10:08:55 - INFO - [disk-ops-1] Coldplug ✓: 3/3 attached, boot=16.82s, total=65.75s
2026-06-16 10:08:55 - INFO - [disk-ops-1] Testing unplug...

======================================================================
DISK OPERATIONS BENCHMARK RESULTS
======================================================================

HOTPLUG:
  Success Rate:      1/1 (100.0%)
  Disks Attached:    3
  Disks Validated:   3
  Avg API Time:      6.43s
  Avg Volume Ready:  2.46s
  Avg Total Time:    50.01s

COLDPLUG:
  Success Rate:      1/1 (100.0%)
  Disks Attached:    3
  Disks Validated:   3
  Avg API Time:      6.64s
  Avg VM Boot Time:  16.82s
  Avg Total Time:    65.75s

UNPLUG:
  Success Rate:      2/2 (100.0%)
  Disks Removed:     6
  Avg Total Time:    8.32s
======================================================================
sayalasomayajula@sayalasomayajula--Mac15 vm-templates % ls
fio-vm-template.yaml		results				rhel9-vm-datasource.yaml	rhel9-vm-registry.yaml		vm-template.yaml		vm.yaml
sayalasomayajula@sayalasomayajula--Mac15 vm-templates % virtbench fio-benchmark -h
Usage: virtbench [OPTIONS] COMMAND [ARGS]...
Try 'virtbench -h' for help.

Error: No such command 'fio-benchmark'.
sayalasomayajula@sayalasomayajula--Mac15 vm-templates % virtbench -h
Usage: virtbench [OPTIONS] COMMAND [ARGS]...

  virtbench - KubeVirt Benchmark Suite

  Performance testing toolkit for KubeVirt virtual machines running on
  OpenShift Container Platform (OCP).

  Available Commands:
    datasource-clone     Run DataSource clone benchmark
    migration            Run VM migration benchmark
    chaos-benchmark      Run chaos benchmark (concurrent VM/volume operations)
    failure-recovery     Run failure recovery benchmark
    fio                  Run FIO benchmark across VMs
    elbencho             Manage elbencho workloads on VMs
    disk-ops             Run disk hotplug/coldplug benchmark
    vm-ops               VM operations (drain, rebalance, snapshot, blkdiscard, power)
    validate-cluster     Validate cluster prerequisites
    version              Print version information

  Examples:
    # Validate cluster
    virtbench validate-cluster --storage-class YOUR-STORAGE-CLASS

    # Run datasource clone test   virtbench datasource-clone --start 1 --end
    10 --storage-class YOUR-STORAGE-CLASS

    # Run migration test   virtbench migration --start 1 --end 5 --source-node
    worker-1

    # Manage elbencho workloads   virtbench elbencho -p datasource-clone -s 1
    -e 10 -n rhel-elbencho-1 -a status

  Global Flags:
    --log-level          Log level: debug, info, warn, error (default: info)
    --log-file           Log file path (auto-generated if not specified)
    --kubeconfig         Path to kubeconfig file
    --timeout            Benchmark timeout (default: 4h)
    --uuid               Benchmark UUID (auto-generated if not specified)

Options:
  --version                       Show the version and exit.
  --log-level [debug|info|warn|error]
                                  Log level
  --log-file PATH                 Log file path (auto-generated if not
                                  specified)
  --kubeconfig PATH               Path to kubeconfig file
  --timeout TEXT                  Benchmark timeout (default: 4h)
  --uuid TEXT                     Benchmark UUID (auto-generated if not
                                  specified)
  -h, --help                      Show this message and exit.

Commands:
  chaos-benchmark   Run chaos benchmark
  datasource-clone  Run DataSource clone benchmark
  disk-ops          Run disk operations benchmark (hotplug/coldplug)
  elbencho          Manage elbencho workloads on VMs
  failure-recovery  Run failure recovery benchmark
  fio               Run FIO benchmark across multiple VMs
  migration         Run VM migration benchmark
  validate-cluster  Validate cluster prerequisites Checks that the...
  version           Print version information
  vm-ops            VM operations toolkit.
sayalasomayajula@sayalasomayajula--Mac15 vm-templates % virtbench fio -h
Usage: virtbench fio [OPTIONS]

  Run FIO benchmark across multiple VMs

  This workload tests storage I/O performance by running FIO benchmarks on
  multiple VMs in parallel. Results include IOPS, bandwidth, and latency.

  Actions:
    deploy         Deploy VMs with FIO pre-configured (FIO runs on boot)
    status         Check VM and FIO status
    gather-results Collect FIO results from VMs (requires SSH pod)
    cleanup        Delete VMs and namespaces
    run-all        Full workflow: deploy, wait, gather (default)

  Notes:
    --save-results is a FLAG that saves results to JSON/CSV files
    --action gather-results is an ACTION that collects results from VMs
    Use both together: --action gather-results --save-results

  Examples:
    # Full workflow (deploy + wait + gather + save)
    virtbench fio --action run-all -s 1 -e 10 --storage-class px-csi --save-results

    # Step-by-step workflow   virtbench fio --action deploy -s 1 -e 10
    --storage-class px-csi   virtbench fio --action status -s 1 -e 10
    virtbench fio --action gather-results -s 1 -e 10 --save-results
    virtbench fio --action cleanup -s 1 -e 10

    # Custom FIO parameters   virtbench fio -a run-all -s 1 -e 50 --storage-
    class px-csi \       --fio-runtime 600 --fio-rw randrw --fio-bs 8k --save-
    results

Options:
  -a, --action [deploy|status|gather-results|cleanup|run-all]
                                  Action to perform
  -s, --start INTEGER             Start index for test namespaces  [required]
  -e, --end INTEGER               End index for test namespaces  [required]
  --storage-class TEXT            Storage class name (required for deploy/run-
                                  all)
  -n, --vm-name TEXT              VM resource name
  --vm-template TEXT              Path to VM template YAML
  --namespace-prefix TEXT         Namespace prefix
  -c, --concurrency INTEGER       Max parallel threads
  --fio-runtime INTEGER           FIO runtime in seconds
  --fio-bs TEXT                   Block size (e.g., 4k, 8k, 64k)
  --fio-rw [read|write|randread|randwrite|randrw|rw]
                                  I/O pattern
  --fio-iodepth INTEGER           I/O depth
  --fio-numjobs INTEGER           Number of parallel jobs
  --fio-size TEXT                 Test file size
  --results-dir TEXT              Base directory for results
  --storage-driver TEXT           Storage driver label for results folder
  --disks-per-vm TEXT             Disks per VM for results folder (auto-
                                  detect)
  --save-results                  Save results to JSON/CSV files
  --cleanup / --no-cleanup        Delete VMs after test (for run-all)
  --collect-retries INTEGER       Max retries for collecting results
  --collect-retry-delay INTEGER   Delay (seconds) between retries
  --collect-concurrency INTEGER   Max concurrent result collections
  --ssh-pod TEXT                  SSH helper pod name (must have sshpass)
  --ssh-pod-ns TEXT               SSH helper pod namespace
  --vm-user TEXT                  VM SSH user
  --vm-password TEXT              VM SSH password
  --log-file PATH                 Log file path
  --log-level [DEBUG|INFO|WARNING|ERROR]
  -h, --help                      Show this message and exit.
sayalasomayajula@sayalasomayajula--Mac15 vm-templates % virtbench fio -s 1 -e 1 --storage-class px-fa-direct-access --vm-name fio-vm --vm-template /Users/sayalasomayajula/kubevirt-benchmark/examples/vm-templates/fio-vm-template.yaml --namespace-prefix fio-benchmark --concurrency 20 --fio-runtime 300 --fio-bs 4k --fio-rw randwrite --fio-iodepth 64 --fio-numjobs 4 --fio-size 10G --results-dir results --log-level INFO

================================================================================
  FIO Benchmark
================================================================================

Running: /Library/Developer/CommandLineTools/usr/bin/python3 /Users/sayalasomayajula/kubevirt-benchmark/io-benchmark/fio/measure-fio-performance.py --action...
Full command: /Library/Developer/CommandLineTools/usr/bin/python3 /Users/sayalasomayajula/kubevirt-benchmark/io-benchmark/fio/measure-fio-performance.py --action run-all --start 1 --end 1 --storage-class px-fa-direct-access --vm-name fio-vm --vm-template
/Users/sayalasomayajula/kubevirt-benchmark/examples/vm-templates/fio-vm-template.yaml --namespace-prefix fio-benchmark --concurrency 20 --fio-runtime 300 --fio-bs 4k --fio-rw randwrite --fio-iodepth 64 --fio-numjobs 4 --fio-size 10G --results-dir results --storage-driver
Not-Specified --disks-per-vm auto --log-level INFO --collect-retries 8 --collect-retry-delay 20 --collect-concurrency 5 --ssh-pod ssh-test-pod --ssh-pod-ns default --vm-user cloud-user --vm-password changeme


============================================================
FIO BENCHMARK - FULL RUN
============================================================
Namespaces: fio-benchmark-1 to fio-benchmark-1 (1 VMs)
Storage Class: px-fa-direct-access
FIO Config: randwrite | bs=4k | iodepth=64 | numjobs=4 | runtime=300s
============================================================

[1/4] Creating namespaces...
2026-06-16 10:22:13 - INFO - Creating 1 namespaces in batches of 20...
2026-06-16 10:22:15 - INFO - Created namespace: fio-benchmark-1
2026-06-16 10:22:15 - INFO - Namespace creation complete: 1 successful, 0 failed
[2/4] Deploying FIO VMs...
  ✓ fio-benchmark-1
[3/4] Waiting for VMs to boot and FIO to complete (polling every 30s)...
2026-06-16 10:23:38 - INFO - [fio-benchmark-1] VM running with IP 172.201.27.194, waiting for FIO...
  ✓ fio-benchmark-1
[4/4] Collecting results...
2026-06-16 10:28:53 - INFO - Auto-detected 2 disks from fio-benchmark-1/fio-vm spec
Output directory: results/Not-Specified/2-disk/20260616-102853_fio_benchmark_1vms
  ✓ fio-benchmark-1

============================================================
FIO BENCHMARK RESULTS
============================================================
Total VMs: 1 | Successful: 1 | Failed: 0
Test Duration: 404.0s

FIO Config: randwrite | bs=4k | iodepth=64 | numjobs=4
------------------------------------------------------------
Metric                        Avg          Max          Min
------------------------------------------------------------
Read Iops                    0.00         0.00         0.00
Write Iops              11,703.59    11,703.59    11,703.59
Read Bw Mibps                0.00         0.00         0.00
Write Bw Mibps              45.72        45.72        45.72
Read Lat Ms                  0.00         0.00         0.00
Write Lat Ms                21.87        21.87        21.87
============================================================

sayalasomayajula@sayalasomayajula--Mac15 vm-templates %
```
